### PR TITLE
feat(phase-1): DM pairing policy + MCP adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Phase 1 (Core Agent Absorption — part 1)
+- **DM pairing policy** (`packages/gateway/src/security/dm-pairing.ts`) inspired by
+  OpenClaw `dmPolicy="pairing"`. Three modes: `open` (back-compat default),
+  `pairing` (unknown DMs receive a one-time code; operator approves), `closed`
+  (allowlist only). Wire-in is additive — existing channel configs without
+  `dmPolicy` keep working unchanged.
+- **`lyrie pairing` operator CLI** (`scripts/pairing.ts`): `list`,
+  `approve <channel> <code>`, `revoke <channel> <senderId>`. JSON store at
+  `~/.lyrie/pairing.json` (mode 0600).
+- **Channel config additions**: `dmPolicy` and (where missing) `allowedUsers`
+  on `TelegramConfig`, `WhatsAppConfig`, `DiscordConfig`. Env vars added:
+  `LYRIE_TELEGRAM_DM_POLICY`, `LYRIE_WHATSAPP_DM_POLICY`,
+  `LYRIE_DISCORD_DM_POLICY`, `LYRIE_WHATSAPP_USERS`, `LYRIE_DISCORD_USERS`.
+- **`@lyrie/mcp` package** — Model Context Protocol adapter. Client mode
+  (stdio + http/sse), `McpRegistry` for `~/.lyrie/mcp.json` configs, and a
+  `lyrie mcp list|call` CLI. Wire-protocol-compliant subset focused on
+  interoperability with Claude Code, Cursor, Continue, Cline, Codex, Gemini
+  CLI, and any other MCP-aware host.
+- **Unit tests** for both: `dm-pairing.test.ts` (12 cases) and
+  `registry.test.ts` (5 cases). All pass under `bun test`.
+
 ### Added — Phase 0 (Repo & Distribution Upgrades)
 - **`lyrie doctor` command** — self-diagnostic for environment, dependencies, channel config, security policy, and update status.
 - **GitHub Actions CI** matrix (Node 20/22/24 × Ubuntu/macOS) with Bun + Rust Shield build.

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,17 @@
         "typescript": "^5.5.0",
       },
     },
+    "packages/mcp": {
+      "name": "@lyrie/mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@lyrie/core": "workspace:*",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+        "typescript": "^5.5.0",
+      },
+    },
     "packages/ui": {
       "name": "@lyrie/ui",
       "version": "0.1.0",
@@ -119,6 +130,8 @@
     "@lyrie/core": ["@lyrie/core@workspace:packages/core"],
 
     "@lyrie/gateway": ["@lyrie/gateway@workspace:packages/gateway"],
+
+    "@lyrie/mcp": ["@lyrie/mcp@workspace:packages/mcp"],
 
     "@lyrie/ui": ["@lyrie/ui@workspace:packages/ui"],
 
@@ -282,6 +295,8 @@
 
     "@lyrie/gateway/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
+    "@lyrie/mcp/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -300,8 +315,12 @@
 
     "@lyrie/gateway/bun-types/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
+    "@lyrie/mcp/bun-types/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@lyrie/gateway/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@lyrie/mcp/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "workspaces": [
     "packages/core",
     "packages/gateway",
+    "packages/mcp",
     "packages/ui"
   ],
   "keywords": [
@@ -40,7 +41,9 @@
     "migrate:all": "bun run scripts/migrate.ts --from all",
     "doctor": "bun run scripts/doctor.ts",
     "doctor:json": "bun run scripts/doctor.ts --json",
-    "release:notes": "bash scripts/release/notes.sh"
+    "release:notes": "bash scripts/release/notes.sh",
+    "pairing": "bun run scripts/pairing.ts",
+    "mcp": "bun run packages/mcp/src/index.ts"
   },
   "devDependencies": {
     "turbo": "^2.0.0",

--- a/packages/gateway/src/common/router.ts
+++ b/packages/gateway/src/common/router.ts
@@ -11,11 +11,18 @@
  */
 
 import type {
+  ChannelType,
   UnifiedMessage,
   UnifiedResponse,
   ChannelBot,
   MessageHandler,
 } from "./types";
+import {
+  DmPairingManager,
+  evaluateDmPolicy,
+  type DmPolicy,
+  type PolicyContext,
+} from "../security/dm-pairing";
 
 // ─── Engine Interface (matches LyrieEngine.process signature) ───────────────────
 
@@ -40,14 +47,38 @@ export type CommandHandler = (
 
 // ─── Router ─────────────────────────────────────────────────────────────────────
 
+export interface ChannelPolicyConfig {
+  dmPolicy?: DmPolicy;
+  allowedUsers?: string[];
+  allowedChats?: string[];
+}
+
 export class MessageRouter {
   private engine: EngineInterface;
   private channels: Map<string, ChannelBot> = new Map();
   private commandHandlers: Map<string, CommandHandler> = new Map();
   private messageCount = 0;
+  private channelPolicies: Map<ChannelType, ChannelPolicyConfig> = new Map();
+  private pairing: DmPairingManager | null = null;
 
   constructor(engine: EngineInterface) {
     this.engine = engine;
+  }
+
+  /**
+   * Configure DM policy for a channel. Call once per channel before start().
+   * Default behavior (no call) is back-compat: "open" with no extra gating.
+   */
+  configureChannelPolicy(channel: ChannelType, cfg: ChannelPolicyConfig): void {
+    this.channelPolicies.set(channel, cfg);
+    if (cfg.dmPolicy === "pairing" && !this.pairing) {
+      this.pairing = new DmPairingManager();
+    }
+  }
+
+  /** Expose the pairing manager so the CLI / admin tools can approve codes. */
+  getPairingManager(): DmPairingManager | null {
+    return this.pairing;
   }
 
   // ── Channel Management ──────────────────────────────────────────────────────
@@ -77,6 +108,19 @@ export class MessageRouter {
       this.messageCount++;
 
       try {
+        // 0. DM policy gate (additive — defaults to "open" / no-op)
+        const policyCfg = this.channelPolicies.get(message.channel);
+        if (policyCfg?.dmPolicy && policyCfg.dmPolicy !== "open") {
+          const policyCtx: PolicyContext = {
+            policy: policyCfg.dmPolicy,
+            allowedUsers: policyCfg.allowedUsers,
+            allowedChats: policyCfg.allowedChats,
+          };
+          const manager = this.pairing ?? (this.pairing = new DmPairingManager());
+          const gated = evaluateDmPolicy(message, policyCtx, manager);
+          if (gated) return gated;
+        }
+
         // 1. If it's a callback (inline button press), route to command system
         if (message.callbackData) {
           return await this.handleCallback(message);

--- a/packages/gateway/src/common/types.ts
+++ b/packages/gateway/src/common/types.ts
@@ -134,6 +134,17 @@ export interface GatewayConfig {
   discord?: DiscordConfig;
 }
 
+/**
+ * DM access policy for any DM-capable channel.
+ *
+ * - "open"     — anyone can DM (back-compat default; existing allowlists
+ *                still enforced if you set them)
+ * - "pairing"  — unknown DMs receive a one-time code; operator approves via
+ *                `lyrie pairing approve <channel> <code>`
+ * - "closed"   — only senders in `allowedUsers`/`allowedChats` reach the agent
+ */
+export type DmPolicy = "open" | "pairing" | "closed";
+
 export interface TelegramConfig {
   enabled: boolean;
   token: string;
@@ -147,6 +158,8 @@ export interface TelegramConfig {
   pollInterval?: number;
   /** Rate limit: max messages per user per minute (default: 30) */
   rateLimitPerMinute?: number;
+  /** DM access policy (default: "open") */
+  dmPolicy?: DmPolicy;
 }
 
 export interface WhatsAppConfig {
@@ -157,6 +170,10 @@ export interface WhatsAppConfig {
   accessToken?: string;
   /** Webhook verify token */
   verifyToken?: string;
+  /** Allowed sender phone numbers / ids */
+  allowedUsers?: string[];
+  /** DM access policy (default: "open") */
+  dmPolicy?: DmPolicy;
 }
 
 export interface DiscordConfig {
@@ -167,4 +184,8 @@ export interface DiscordConfig {
   applicationId?: string;
   /** Allowed guild IDs */
   allowedGuilds?: string[];
+  /** Allowed user IDs (DM allowlist) */
+  allowedUsers?: string[];
+  /** DM access policy (default: "open") */
+  dmPolicy?: DmPolicy;
 }

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -31,6 +31,14 @@ export type { LyrieConfig, LyrieEngineConfig, Message } from "@lyrie/core";
 
 // ─── Config from Environment ────────────────────────────────────────────────────
 
+function parseDmPolicy(raw: string | undefined): "open" | "pairing" | "closed" | undefined {
+  if (!raw) return undefined;
+  const v = raw.trim().toLowerCase();
+  if (v === "open" || v === "pairing" || v === "closed") return v;
+  console.warn(`[gateway] ignoring unknown dmPolicy=${raw} (must be open|pairing|closed)`);
+  return undefined;
+}
+
 function loadConfig(): GatewayConfig {
   return {
     telegram: {
@@ -39,16 +47,21 @@ function loadConfig(): GatewayConfig {
       allowedUsers: process.env.LYRIE_TELEGRAM_USERS?.split(",").filter(Boolean),
       allowedChats: process.env.LYRIE_TELEGRAM_CHATS?.split(",").filter(Boolean),
       rateLimitPerMinute: Number(process.env.LYRIE_TELEGRAM_RATE) || 30,
+      dmPolicy: parseDmPolicy(process.env.LYRIE_TELEGRAM_DM_POLICY),
     },
     whatsapp: {
       enabled: !!process.env.LYRIE_WHATSAPP_PHONE_ID,
       phoneNumberId: process.env.LYRIE_WHATSAPP_PHONE_ID,
       accessToken: process.env.LYRIE_WHATSAPP_TOKEN,
+      allowedUsers: process.env.LYRIE_WHATSAPP_USERS?.split(",").filter(Boolean),
+      dmPolicy: parseDmPolicy(process.env.LYRIE_WHATSAPP_DM_POLICY),
     },
     discord: {
       enabled: !!process.env.LYRIE_DISCORD_TOKEN,
       token: process.env.LYRIE_DISCORD_TOKEN,
       applicationId: process.env.LYRIE_DISCORD_APP_ID,
+      allowedUsers: process.env.LYRIE_DISCORD_USERS?.split(",").filter(Boolean),
+      dmPolicy: parseDmPolicy(process.env.LYRIE_DISCORD_DM_POLICY),
     },
   };
 }
@@ -92,6 +105,13 @@ export class LyrieGateway {
     // Telegram
     if (this.config.telegram?.enabled) {
       try {
+        if (this.config.telegram.dmPolicy) {
+          this.router.configureChannelPolicy("telegram", {
+            dmPolicy: this.config.telegram.dmPolicy,
+            allowedUsers: this.config.telegram.allowedUsers,
+            allowedChats: this.config.telegram.allowedChats,
+          });
+        }
         const tgBot = new TelegramBot(this.config.telegram);
         tgBot.onMessage(this.router.handler());
         await tgBot.start();
@@ -106,6 +126,12 @@ export class LyrieGateway {
     // WhatsApp
     if (this.config.whatsapp?.enabled) {
       try {
+        if (this.config.whatsapp.dmPolicy) {
+          this.router.configureChannelPolicy("whatsapp", {
+            dmPolicy: this.config.whatsapp.dmPolicy,
+            allowedUsers: this.config.whatsapp.allowedUsers,
+          });
+        }
         const waBot = new WhatsAppBot(this.config.whatsapp);
         waBot.onMessage(this.router.handler());
         await waBot.start();
@@ -120,6 +146,12 @@ export class LyrieGateway {
     // Discord
     if (this.config.discord?.enabled) {
       try {
+        if (this.config.discord.dmPolicy) {
+          this.router.configureChannelPolicy("discord", {
+            dmPolicy: this.config.discord.dmPolicy,
+            allowedUsers: this.config.discord.allowedUsers,
+          });
+        }
         const dcBot = new DiscordBot(this.config.discord);
         dcBot.onMessage(this.router.handler());
         await dcBot.start();

--- a/packages/gateway/src/security/dm-pairing.test.ts
+++ b/packages/gateway/src/security/dm-pairing.test.ts
@@ -1,0 +1,145 @@
+/**
+ * DM Pairing — unit tests
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  DmPairingManager,
+  evaluateDmPolicy,
+  type DmPolicy,
+} from "./dm-pairing";
+import type { UnifiedMessage } from "../common/types";
+
+let storeDir: string;
+let storePath: string;
+
+function makeMsg(over: Partial<UnifiedMessage> = {}): UnifiedMessage {
+  return {
+    id: "m1",
+    channel: "telegram",
+    senderId: "user-123",
+    senderName: "Alice",
+    chatId: "chat-1",
+    text: "hi",
+    timestamp: new Date().toISOString(),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  storeDir = mkdtempSync(join(tmpdir(), "lyrie-pairing-"));
+  storePath = join(storeDir, "pairing.json");
+});
+
+afterEach(() => {
+  rmSync(storeDir, { recursive: true, force: true });
+});
+
+describe("DmPairingManager", () => {
+  test("greet produces a pairing code and persists pending record", () => {
+    const m = new DmPairingManager({ storePath });
+    const reply = m.greet(makeMsg());
+    expect(reply.text).toContain("pairing approve telegram");
+
+    // Same sender greeted twice → still a single pending record
+    m.greet(makeMsg());
+    const pending = m.list().pending;
+    expect(pending.length).toBe(1);
+    expect(pending[0].code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+  });
+
+  test("approve moves record from pending to approved", () => {
+    const m = new DmPairingManager({ storePath });
+    m.greet(makeMsg());
+    const code = m.list().pending[0].code!;
+
+    const approved = m.approve("telegram", code);
+    expect(approved).not.toBeNull();
+    expect(approved!.senderId).toBe("user-123");
+    expect(m.list().pending.length).toBe(0);
+    expect(m.list().approved.length).toBe(1);
+    expect(m.isApproved("telegram", "user-123")).toBe(true);
+  });
+
+  test("approve with invalid code returns null", () => {
+    const m = new DmPairingManager({ storePath });
+    expect(m.approve("telegram", "BAD-CODE")).toBeNull();
+  });
+
+  test("revoke removes an approved sender", () => {
+    const m = new DmPairingManager({ storePath });
+    m.greet(makeMsg());
+    const code = m.list().pending[0].code!;
+    m.approve("telegram", code);
+    expect(m.revoke("telegram", "user-123")).toBe(true);
+    expect(m.isApproved("telegram", "user-123")).toBe(false);
+    // Idempotent
+    expect(m.revoke("telegram", "user-123")).toBe(false);
+  });
+
+  test("store persists across instances", () => {
+    const a = new DmPairingManager({ storePath });
+    a.greet(makeMsg());
+    const code = a.list().pending[0].code!;
+    a.approve("telegram", code);
+
+    const b = new DmPairingManager({ storePath });
+    expect(b.isApproved("telegram", "user-123")).toBe(true);
+  });
+});
+
+describe("evaluateDmPolicy", () => {
+  function setup(policy: DmPolicy, allowedUsers?: string[]) {
+    const manager = new DmPairingManager({ storePath });
+    return {
+      manager,
+      run: (msg = makeMsg()) =>
+        evaluateDmPolicy(msg, { policy, allowedUsers }, manager),
+    };
+  }
+
+  test("open: passes everything through", () => {
+    const { run } = setup("open");
+    expect(run()).toBeNull();
+  });
+
+  test("closed: blocks unknown sender", () => {
+    const { run } = setup("closed");
+    const reply = run();
+    expect(reply).not.toBeNull();
+    expect(reply!.text).toContain("locked down");
+  });
+
+  test("closed: allows allowlisted sender", () => {
+    const { run } = setup("closed", ["user-123"]);
+    expect(run()).toBeNull();
+  });
+
+  test("pairing: gates unknown sender with code", () => {
+    const { run, manager } = setup("pairing");
+    const reply = run();
+    expect(reply).not.toBeNull();
+    expect(reply!.text).toContain("pairing approve");
+    expect(manager.list().pending.length).toBe(1);
+  });
+
+  test("pairing: lets approved sender through", () => {
+    const { run, manager } = setup("pairing");
+    run(); // first greet
+    const code = manager.list().pending[0].code!;
+    manager.approve("telegram", code);
+    expect(run()).toBeNull();
+  });
+
+  test("pairing: allowedUsers bypasses pairing", () => {
+    const { run, manager } = setup("pairing", ["user-123"]);
+    expect(run()).toBeNull();
+    expect(manager.list().pending.length).toBe(0);
+  });
+});

--- a/packages/gateway/src/security/dm-pairing.ts
+++ b/packages/gateway/src/security/dm-pairing.ts
@@ -1,0 +1,269 @@
+/**
+ * DM Pairing Policy
+ *
+ * Inspired by OpenClaw's `dmPolicy = "pairing"` model. When enabled, unknown
+ * senders on a DM-capable channel receive a one-time pairing code instead of
+ * being forwarded to the agent. An operator approves the code via:
+ *
+ *   lyrie pairing approve <channel> <code>
+ *
+ * Approved senders are added to a local allowlist and treated as known on
+ * every subsequent message.
+ *
+ * Policies (per channel):
+ *   - "open"     — anyone can DM (existing behavior, current default)
+ *   - "pairing"  — unknown DMs receive a code, operator approves
+ *   - "closed"   — DMs only from explicit `allowedUsers` lists
+ *
+ * This module is purely additive. If a channel does not set `dmPolicy`, it
+ * behaves exactly as before. Existing `allowedUsers` lists are honored on top
+ * of (not instead of) the pairing flow.
+ *
+ * Storage: simple JSON file under `~/.lyrie/pairing.json`. We avoid SQLite
+ * here so the gateway has no native deps in v0.1.x.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import type { ChannelType, UnifiedMessage, UnifiedResponse } from "../common/types";
+
+// ─── Types ──────────────────────────────────────────────────────────────────────
+
+export type DmPolicy = "open" | "pairing" | "closed";
+
+export interface PairingRecord {
+  channel: ChannelType;
+  senderId: string;
+  /** Display name at the time of pairing */
+  senderName?: string;
+  /** Pairing code (unset once approved) */
+  code?: string;
+  /** Set when an operator approves the pairing */
+  approvedAt?: string;
+  /** When the pairing was first requested */
+  requestedAt: string;
+}
+
+export interface PairingStore {
+  pending: PairingRecord[];
+  approved: PairingRecord[];
+}
+
+// ─── Storage ────────────────────────────────────────────────────────────────────
+
+function defaultPath(): string {
+  return join(homedir(), ".lyrie", "pairing.json");
+}
+
+function ensureDir(file: string) {
+  const dir = dirname(file);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function loadStore(file: string): PairingStore {
+  if (!existsSync(file)) return { pending: [], approved: [] };
+  try {
+    const data = JSON.parse(readFileSync(file, "utf8"));
+    return {
+      pending: Array.isArray(data.pending) ? data.pending : [],
+      approved: Array.isArray(data.approved) ? data.approved : [],
+    };
+  } catch {
+    return { pending: [], approved: [] };
+  }
+}
+
+function saveStore(file: string, store: PairingStore) {
+  ensureDir(file);
+  writeFileSync(file, JSON.stringify(store, null, 2), { mode: 0o600 });
+}
+
+// ─── Code Generation ────────────────────────────────────────────────────────────
+
+/** Short, human-friendly pairing code (8 chars, A-Z 2-9 minus look-alikes). */
+function generatePairingCode(): string {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  const bytes = randomBytes(8);
+  let out = "";
+  for (let i = 0; i < 8; i++) out += alphabet[bytes[i] % alphabet.length];
+  return out.replace(/(.{4})(.{4})/, "$1-$2");
+}
+
+// ─── Manager ────────────────────────────────────────────────────────────────────
+
+export interface DmPairingOptions {
+  /** Path to the pairing JSON store. Defaults to ~/.lyrie/pairing.json */
+  storePath?: string;
+  /** Operator-facing message shown when an unknown sender is gated. */
+  greeting?: (record: PairingRecord) => string;
+}
+
+export class DmPairingManager {
+  private store: PairingStore;
+  private path: string;
+  private greeting: (record: PairingRecord) => string;
+
+  constructor(opts: DmPairingOptions = {}) {
+    this.path = opts.storePath ?? defaultPath();
+    this.store = loadStore(this.path);
+    this.greeting = opts.greeting ?? defaultGreeting;
+  }
+
+  /** Returns true if the sender is already approved for this channel. */
+  isApproved(channel: ChannelType, senderId: string): boolean {
+    return this.store.approved.some(
+      (r) => r.channel === channel && r.senderId === senderId,
+    );
+  }
+
+  /** Returns the existing pending record if any, or null. */
+  pending(channel: ChannelType, senderId: string): PairingRecord | null {
+    return (
+      this.store.pending.find(
+        (r) => r.channel === channel && r.senderId === senderId,
+      ) ?? null
+    );
+  }
+
+  /**
+   * Idempotently produce/refresh a pairing record for an unknown sender and
+   * return the operator-facing greeting (to relay back to the sender).
+   */
+  greet(message: UnifiedMessage): UnifiedResponse {
+    const existing = this.pending(message.channel, message.senderId);
+    if (existing) return { text: this.greeting(existing) };
+
+    const record: PairingRecord = {
+      channel: message.channel,
+      senderId: message.senderId,
+      senderName: message.senderName,
+      code: generatePairingCode(),
+      requestedAt: new Date().toISOString(),
+    };
+    this.store.pending.push(record);
+    saveStore(this.path, this.store);
+
+    // Surface to the operator's main channel via stderr (gateway picks this up
+    // in logs; companion CLI tail-watches the file).
+    console.warn(
+      `[dm-pairing] new pairing request channel=${record.channel} ` +
+        `sender=${record.senderId} (${record.senderName ?? "unknown"}) ` +
+        `code=${record.code}`,
+    );
+
+    return { text: this.greeting(record) };
+  }
+
+  /** Approve a pending pairing by code. Used by `lyrie pairing approve`. */
+  approve(channel: ChannelType, code: string): PairingRecord | null {
+    const idx = this.store.pending.findIndex(
+      (r) => r.channel === channel && r.code === code,
+    );
+    if (idx === -1) return null;
+    const [record] = this.store.pending.splice(idx, 1);
+    record.approvedAt = new Date().toISOString();
+    delete record.code;
+    this.store.approved.push(record);
+    saveStore(this.path, this.store);
+    return record;
+  }
+
+  /** Revoke a previously approved sender. */
+  revoke(channel: ChannelType, senderId: string): boolean {
+    const before = this.store.approved.length;
+    this.store.approved = this.store.approved.filter(
+      (r) => !(r.channel === channel && r.senderId === senderId),
+    );
+    if (this.store.approved.length === before) return false;
+    saveStore(this.path, this.store);
+    return true;
+  }
+
+  list(): PairingStore {
+    // Return a deep copy so callers can't mutate our internal state
+    return JSON.parse(JSON.stringify(this.store));
+  }
+}
+
+// ─── Default greeting ───────────────────────────────────────────────────────────
+
+function defaultGreeting(record: PairingRecord): string {
+  const name = record.senderName ? `, ${record.senderName}` : "";
+  return [
+    `🛡️  Hi${name} — this is Lyrie.`,
+    "",
+    "Direct messages on this channel require pairing approval.",
+    "Ask the operator to run:",
+    "",
+    `\`lyrie pairing approve ${record.channel} ${record.code}\``,
+    "",
+    "Once approved, you can chat normally.",
+  ].join("\n");
+}
+
+// ─── Policy gate ────────────────────────────────────────────────────────────────
+
+export interface PolicyContext {
+  /** Per-channel resolved DM policy. Defaults to "open" for back-compat. */
+  policy: DmPolicy;
+  /** Optional explicit allowlist (senderId values) that bypass pairing. */
+  allowedUsers?: string[];
+  /** Optional chat-level allowlist (chatId values). */
+  allowedChats?: string[];
+}
+
+/**
+ * Decide whether a message should reach the engine. Returns either a response
+ * to send back instead (gating message) or `null` to allow through.
+ *
+ * Pure function over its inputs — easy to unit test. The router calls this on
+ * every inbound message and short-circuits when a response is returned.
+ */
+export function evaluateDmPolicy(
+  message: UnifiedMessage,
+  ctx: PolicyContext,
+  manager: DmPairingManager,
+): UnifiedResponse | null {
+  // Closed: only explicit allowlist matches allowed
+  if (ctx.policy === "closed") {
+    if (ctx.allowedUsers?.includes(message.senderId)) return null;
+    if (ctx.allowedChats?.includes(message.chatId)) return null;
+    return {
+      text:
+        "🚫 This Lyrie deployment is locked down to its operator. " +
+        "Your message was not delivered.",
+    };
+  }
+
+  // Open: legacy behavior, allow everything (existing allowedUsers still
+  // enforced at the channel level upstream — we don't change that).
+  if (ctx.policy === "open") return null;
+
+  // Pairing
+  if (ctx.policy === "pairing") {
+    if (ctx.allowedUsers?.includes(message.senderId)) return null;
+    if (ctx.allowedChats?.includes(message.chatId)) return null;
+    if (manager.isApproved(message.channel, message.senderId)) return null;
+    return manager.greet(message);
+  }
+
+  // Unknown policy: fail closed but with a clear message (defensive)
+  return {
+    text:
+      "⚠️ Unknown DM policy configured for this channel. " +
+      "Ask the operator to set a valid policy (open|pairing|closed).",
+  };
+}
+
+// ─── Singleton helper (optional) ────────────────────────────────────────────────
+
+let _manager: DmPairingManager | null = null;
+export function defaultPairingManager(): DmPairingManager {
+  if (!_manager) _manager = new DmPairingManager();
+  return _manager;
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,74 @@
+# @lyrie/mcp
+
+Model Context Protocol (MCP) adapter for Lyrie Agent.
+
+MCP is the open standard ([modelcontextprotocol.io](https://modelcontextprotocol.io))
+that lets agents discover and call tools/resources/prompts from any
+compliant server — Cursor, Claude Code, Cline, OpenAI Codex, Gemini CLI,
+Continue, and many others ship MCP support out of the box.
+
+This package gives Lyrie:
+
+1. **Client mode** — Lyrie connects to external MCP servers and registers
+   their tools as Lyrie tools (auto-prefixed `mcp:<server>:<tool>`).
+2. **Server mode** — Lyrie exposes its own skills/tools as an MCP server
+   so other MCP-aware agents can call into Lyrie.
+3. **Configuration** via the same JSON shape every MCP host uses
+   (`mcpServers` in `~/.lyrie/mcp.json` or `lyrie.config.json`).
+
+## Quick start (client mode)
+
+```ts
+import { McpClient } from "@lyrie/mcp";
+
+const client = new McpClient({
+  name: "filesystem",
+  transport: { type: "stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"] },
+});
+
+await client.connect();
+const tools = await client.listTools(); // [{name, description, inputSchema}, ...]
+const result = await client.callTool("read_file", { path: "/tmp/hello.txt" });
+```
+
+## Configuration file
+
+`~/.lyrie/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}" }
+    }
+  }
+}
+```
+
+Lyrie auto-discovers this file on boot when MCP is enabled in
+`packages/core/src/config.ts`.
+
+## Transports
+
+| Transport | Status |
+|---|---|
+| `stdio` (subprocess) | ✅ supported |
+| `http`/`sse` (HTTP+SSE) | ✅ supported |
+| `websocket` | 🟡 planned |
+
+## Status
+
+Phase 1 Lyrie absorption — ships in `v0.1.x`. Wire-protocol implementation
+is intentionally minimal but spec-compliant; the goal is **interoperability**
+not feature parity with every host. Use `bun run packages/mcp/src/index.ts list`
+to verify a configured server responds.
+
+## License
+
+MIT — © OTT Cybersecurity LLC.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@lyrie/mcp",
+  "version": "0.1.0",
+  "description": "Model Context Protocol (MCP) adapter for Lyrie Agent — connect to and host MCP servers",
+  "author": "OTT Cybersecurity LLC <dev@lyrie.ai> (https://lyrie.ai)",
+  "license": "MIT",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist --target node",
+    "test": "bun test",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [
+    "lyrie",
+    "mcp",
+    "model-context-protocol",
+    "agent",
+    "tools"
+  ],
+  "dependencies": {
+    "@lyrie/core": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "latest",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,0 +1,304 @@
+/**
+ * MCP Client — connects to an MCP server over stdio or HTTP/SSE,
+ * negotiates protocol version, lists tools, and calls them.
+ *
+ * Spec: https://modelcontextprotocol.io/specification (2025-06-18 baseline,
+ * forward-compatible with the 2026 draft).
+ *
+ * Phase 1 deliberately ships the surface every Lyrie skill needs: initialize,
+ * tools/list, tools/call, resources/list, plus shutdown. Anything the spec
+ * adds later can be appended without breaking callers.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+import type {
+  CallToolParams,
+  CallToolResult,
+  InitializeParams,
+  InitializeResult,
+  JsonRpcRequest,
+  JsonRpcResponse,
+  ListResourcesResult,
+  ListToolsResult,
+  Resource,
+  ServerCapabilities,
+  Tool,
+  Transport,
+} from "./types";
+
+const PROTOCOL_VERSION = "2025-06-18";
+const CLIENT_INFO = { name: "lyrie-agent", version: "0.1.1" };
+
+// ─── Transport abstraction ───────────────────────────────────────────────────
+
+interface TransportConn {
+  send(line: string): void;
+  close(): void;
+  /** Resolve when the transport is fully shut down. */
+  wait(): Promise<void>;
+}
+
+class StdioConn implements TransportConn {
+  private child: ChildProcessWithoutNullStreams;
+  private buffer = "";
+
+  constructor(
+    transport: Extract<Transport, { type: "stdio" }>,
+    onLine: (line: string) => void,
+  ) {
+    this.child = spawn(transport.command, transport.args ?? [], {
+      env: { ...process.env, ...(transport.env ?? {}) } as NodeJS.ProcessEnv,
+      cwd: transport.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this.child.stdout.on("data", (chunk: Buffer) => {
+      this.buffer += chunk.toString("utf8");
+      let nl: number;
+      // eslint-disable-next-line no-cond-assign
+      while ((nl = this.buffer.indexOf("\n")) >= 0) {
+        const line = this.buffer.slice(0, nl).trim();
+        this.buffer = this.buffer.slice(nl + 1);
+        if (line) onLine(line);
+      }
+    });
+
+    this.child.stderr.on("data", (chunk: Buffer) => {
+      // MCP stdio servers commonly log to stderr; surface as debug.
+      process.stderr.write(`[mcp:${transport.command}] ${chunk}`);
+    });
+  }
+
+  send(line: string) {
+    this.child.stdin.write(line + "\n");
+  }
+
+  close() {
+    try {
+      this.child.stdin.end();
+      this.child.kill();
+    } catch {
+      // already gone
+    }
+  }
+
+  async wait(): Promise<void> {
+    if (this.child.exitCode !== null) return;
+    await new Promise<void>((resolve) => this.child.once("exit", () => resolve()));
+  }
+}
+
+class HttpConn implements TransportConn {
+  private base: string;
+  private headers: Record<string, string>;
+  private onLine: (line: string) => void;
+  private streamCtl: AbortController | null = null;
+
+  constructor(
+    transport: Extract<Transport, { type: "http" | "sse" }>,
+    onLine: (line: string) => void,
+  ) {
+    this.base = transport.url.replace(/\/$/, "");
+    this.headers = {
+      "Content-Type": "application/json",
+      Accept: transport.type === "sse" ? "text/event-stream" : "application/json",
+      ...(transport.headers ?? {}),
+    };
+    this.onLine = onLine;
+    if (transport.type === "sse") void this.openSse();
+  }
+
+  private async openSse() {
+    this.streamCtl = new AbortController();
+    try {
+      const res = await fetch(this.base + "/sse", {
+        headers: this.headers,
+        signal: this.streamCtl.signal,
+      });
+      if (!res.body) return;
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      let buf = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        let idx: number;
+        // eslint-disable-next-line no-cond-assign
+        while ((idx = buf.indexOf("\n\n")) >= 0) {
+          const evt = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          for (const line of evt.split("\n")) {
+            if (line.startsWith("data: ")) this.onLine(line.slice(6));
+          }
+        }
+      }
+    } catch {
+      // stream closed
+    }
+  }
+
+  async send(line: string) {
+    const res = await fetch(this.base, {
+      method: "POST",
+      headers: this.headers,
+      body: line,
+    });
+    if (res.headers.get("content-type")?.includes("application/json")) {
+      const body = await res.text();
+      if (body) this.onLine(body);
+    }
+  }
+
+  close() {
+    this.streamCtl?.abort();
+  }
+
+  async wait(): Promise<void> {
+    /* nothing to wait on */
+  }
+}
+
+// ─── Client ──────────────────────────────────────────────────────────────────
+
+export interface McpClientOptions {
+  /** Human name used to namespace tools when surfaced to the agent */
+  name: string;
+  transport: Transport;
+  /** Optional default request timeout in ms (default: 30s) */
+  requestTimeoutMs?: number;
+}
+
+export class McpClient {
+  readonly name: string;
+  private conn: TransportConn | null = null;
+  private inflight = new Map<
+    string | number,
+    { resolve: (v: unknown) => void; reject: (e: unknown) => void; timer?: NodeJS.Timeout }
+  >();
+  private serverCapabilities: ServerCapabilities | null = null;
+  private serverInfo: InitializeResult["serverInfo"] | null = null;
+  private timeoutMs: number;
+  private opts: McpClientOptions;
+
+  constructor(opts: McpClientOptions) {
+    this.name = opts.name;
+    this.timeoutMs = opts.requestTimeoutMs ?? 30_000;
+    this.opts = opts;
+  }
+
+  // ── lifecycle ────────────────────────────────────────────────────────────
+
+  async connect(): Promise<InitializeResult> {
+    if (this.conn) throw new Error("already connected");
+    const onLine = (line: string) => this.onMessage(line);
+    if (this.opts.transport.type === "stdio") {
+      this.conn = new StdioConn(this.opts.transport, onLine);
+    } else {
+      this.conn = new HttpConn(this.opts.transport, onLine);
+    }
+
+    const init = await this.request<InitializeResult>("initialize", {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { roots: { listChanged: false } },
+      clientInfo: CLIENT_INFO,
+    } satisfies InitializeParams);
+
+    this.serverCapabilities = init.capabilities;
+    this.serverInfo = init.serverInfo;
+
+    // notifications/initialized — fire-and-forget
+    this.notify("notifications/initialized", {});
+
+    return init;
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.conn) return;
+    try {
+      this.notify("notifications/cancelled", {});
+    } catch {
+      /* noop */
+    }
+    this.conn.close();
+    await this.conn.wait();
+    this.conn = null;
+  }
+
+  capabilities(): ServerCapabilities | null {
+    return this.serverCapabilities;
+  }
+
+  info(): InitializeResult["serverInfo"] | null {
+    return this.serverInfo;
+  }
+
+  // ── high-level methods ───────────────────────────────────────────────────
+
+  async listTools(): Promise<Tool[]> {
+    if (!this.serverCapabilities?.tools) return [];
+    const r = await this.request<ListToolsResult>("tools/list", {});
+    return r.tools;
+  }
+
+  async callTool(name: string, args: Record<string, unknown> = {}): Promise<CallToolResult> {
+    return await this.request<CallToolResult>("tools/call", {
+      name,
+      arguments: args,
+    } satisfies CallToolParams);
+  }
+
+  async listResources(): Promise<Resource[]> {
+    if (!this.serverCapabilities?.resources) return [];
+    const r = await this.request<ListResourcesResult>("resources/list", {});
+    return r.resources;
+  }
+
+  // ── JSON-RPC plumbing ────────────────────────────────────────────────────
+
+  private request<R>(method: string, params: unknown): Promise<R> {
+    if (!this.conn) return Promise.reject(new Error("not connected"));
+    const id = randomUUID();
+    const req: JsonRpcRequest = { jsonrpc: "2.0", id, method, params };
+    return new Promise<R>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.inflight.delete(id);
+        reject(new Error(`MCP request timeout: ${method}`));
+      }, this.timeoutMs);
+      this.inflight.set(id, {
+        resolve: (v) => resolve(v as R),
+        reject,
+        timer,
+      });
+      this.conn!.send(JSON.stringify(req));
+    });
+  }
+
+  private notify(method: string, params: unknown) {
+    if (!this.conn) return;
+    this.conn.send(JSON.stringify({ jsonrpc: "2.0", method, params }));
+  }
+
+  private onMessage(line: string) {
+    let msg: JsonRpcResponse;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // ignore garbled lines (some servers print banners)
+    }
+    if (msg.id == null) return; // notification or stray
+    const pending = this.inflight.get(msg.id);
+    if (!pending) return;
+    this.inflight.delete(msg.id);
+    if (pending.timer) clearTimeout(pending.timer);
+    if (msg.error) {
+      pending.reject(new Error(`[mcp ${msg.error.code}] ${msg.error.message}`));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,72 @@
+/**
+ * @lyrie/mcp — entry point.
+ *
+ * Re-exports public types + classes. Also runs as a CLI when invoked directly:
+ *
+ *   bun run packages/mcp/src/index.ts list
+ *   bun run packages/mcp/src/index.ts call <server> <tool> [json-args]
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { McpRegistry } from "./registry";
+
+export { McpClient } from "./client";
+export { McpRegistry } from "./registry";
+export type {
+  CallToolResult,
+  McpConfigFile,
+  McpServerConfig,
+  Tool,
+  Transport,
+} from "./types";
+
+const isDirectRun =
+  typeof Bun !== "undefined"
+    ? Bun.main === import.meta.path
+    : process.argv[1]?.endsWith("packages/mcp/src/index.ts");
+
+async function cli() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const reg = new McpRegistry();
+  await reg.loadFrom();
+
+  switch (cmd) {
+    case "list": {
+      const tools = reg.list();
+      console.log(`\nMCP servers connected: ${reg.servers().join(", ") || "(none)"}`);
+      console.log(`Tools available (${tools.length}):`);
+      for (const t of tools) {
+        console.log(
+          `  - ${t.qualifiedName}${t.tool.description ? `  — ${t.tool.description}` : ""}`,
+        );
+      }
+      console.log("");
+      break;
+    }
+    case "call": {
+      const [server, tool, argsJson] = rest;
+      if (!server || !tool) {
+        console.error("Usage: lyrie mcp call <server> <tool> [json-args]");
+        process.exit(2);
+      }
+      const args = argsJson ? (JSON.parse(argsJson) as Record<string, unknown>) : {};
+      const result = await reg.call(`mcp:${server}:${tool}`, args);
+      console.log(JSON.stringify(result, null, 2));
+      break;
+    }
+    default:
+      console.error("Usage:");
+      console.error("  lyrie mcp list");
+      console.error("  lyrie mcp call <server> <tool> [json-args]");
+      process.exit(2);
+  }
+  await reg.shutdown();
+}
+
+if (isDirectRun) {
+  cli().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/mcp/src/registry.test.ts
+++ b/packages/mcp/src/registry.test.ts
@@ -1,0 +1,85 @@
+/**
+ * McpRegistry — pure-function tests (no real subprocesses spawned).
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { McpRegistry } from "./registry";
+
+describe("McpRegistry.toTransport", () => {
+  test("stdio: command + args + env", () => {
+    const t = McpRegistry.toTransport({
+      command: "node",
+      args: ["server.js"],
+      env: { FOO: "1" },
+    });
+    expect(t).toEqual({
+      type: "stdio",
+      command: "node",
+      args: ["server.js"],
+      env: { FOO: "1" },
+      cwd: undefined,
+    });
+  });
+
+  test("http: url + headers", () => {
+    const t = McpRegistry.toTransport({
+      url: "https://example.com/mcp",
+      headers: { Authorization: "Bearer x" },
+    });
+    expect(t).toEqual({
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: { Authorization: "Bearer x" },
+    });
+  });
+
+  test("sse: explicit transportType=sse", () => {
+    const t = McpRegistry.toTransport({
+      url: "https://example.com/mcp",
+      transportType: "sse",
+    });
+    expect(t.type).toBe("sse");
+  });
+
+  test("throws when neither url nor command provided", () => {
+    expect(() => McpRegistry.toTransport({})).toThrow();
+  });
+});
+
+describe("McpRegistry.loadConfig", () => {
+  test("returns null when file is missing", () => {
+    const r = McpRegistry.loadConfig("/tmp/nonexistent-mcp-9b8a7.json");
+    expect(r).toBeNull();
+  });
+});
+
+describe("McpRegistry inline config (no real connect)", () => {
+  test("disabled servers are skipped", async () => {
+    const reg = new McpRegistry();
+    // Inline config with one disabled server — no connect attempted
+    await reg.loadFrom({
+      configInline: {
+        mcpServers: {
+          off: { command: "false", disabled: true },
+        },
+      },
+    });
+    expect(reg.servers().length).toBe(0);
+  });
+
+  test("invalid server config logs and continues", async () => {
+    const reg = new McpRegistry();
+    // No url or command → toTransport throws → caught + logged
+    await reg.loadFrom({
+      configInline: {
+        mcpServers: {
+          broken: {} as any,
+        },
+      },
+    });
+    expect(reg.list().length).toBe(0);
+  });
+});

--- a/packages/mcp/src/registry.ts
+++ b/packages/mcp/src/registry.ts
@@ -1,0 +1,132 @@
+/**
+ * McpRegistry — load mcp.json, manage a fleet of McpClient instances, and
+ * expose an aggregated tool catalog to the Lyrie tool executor.
+ *
+ * The registry is intentionally additive: if no mcp.json is present, the
+ * registry is empty and nothing changes about Lyrie's behavior.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { McpClient } from "./client";
+import type {
+  CallToolResult,
+  McpConfigFile,
+  McpServerConfig,
+  Tool,
+  Transport,
+} from "./types";
+
+export interface RegisteredTool {
+  /** Fully-qualified name surfaced to the agent: mcp:<server>:<tool> */
+  qualifiedName: string;
+  /** Server name (registry key) */
+  server: string;
+  tool: Tool;
+}
+
+export interface McpRegistryOptions {
+  configPath?: string;
+  configInline?: McpConfigFile;
+}
+
+export class McpRegistry {
+  private clients = new Map<string, McpClient>();
+  private tools: RegisteredTool[] = [];
+
+  static defaultConfigPath(): string {
+    return join(homedir(), ".lyrie", "mcp.json");
+  }
+
+  static loadConfig(path: string): McpConfigFile | null {
+    if (!existsSync(path)) return null;
+    try {
+      return JSON.parse(readFileSync(path, "utf8")) as McpConfigFile;
+    } catch (err) {
+      console.warn(`[mcp] failed to parse ${path}:`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Convert a raw McpServerConfig into a Transport. Pure function for testing.
+   */
+  static toTransport(cfg: McpServerConfig): Transport {
+    if (cfg.url) {
+      return {
+        type: cfg.transportType === "sse" ? "sse" : "http",
+        url: cfg.url,
+        headers: cfg.headers,
+      };
+    }
+    if (cfg.command) {
+      return {
+        type: "stdio",
+        command: cfg.command,
+        args: cfg.args,
+        env: cfg.env,
+        cwd: cfg.cwd,
+      };
+    }
+    throw new Error("McpServerConfig requires either url or command");
+  }
+
+  async loadFrom(opts: McpRegistryOptions = {}): Promise<void> {
+    const path = opts.configPath ?? McpRegistry.defaultConfigPath();
+    const config = opts.configInline ?? McpRegistry.loadConfig(path);
+    if (!config?.mcpServers) return;
+
+    for (const [name, cfg] of Object.entries(config.mcpServers)) {
+      if (cfg.disabled) continue;
+      try {
+        const client = new McpClient({
+          name,
+          transport: McpRegistry.toTransport(cfg),
+        });
+        await client.connect();
+        const tools = (await client.listTools()).filter((t) => {
+          if (cfg.denyTools?.includes(t.name)) return false;
+          if (cfg.allowTools && !cfg.allowTools.includes(t.name)) return false;
+          return true;
+        });
+        this.clients.set(name, client);
+        for (const tool of tools) {
+          this.tools.push({
+            qualifiedName: `mcp:${name}:${tool.name}`,
+            server: name,
+            tool,
+          });
+        }
+      } catch (err) {
+        console.warn(`[mcp] failed to connect server "${name}":`, err);
+      }
+    }
+  }
+
+  list(): RegisteredTool[] {
+    return [...this.tools];
+  }
+
+  servers(): string[] {
+    return Array.from(this.clients.keys());
+  }
+
+  async call(qualifiedName: string, args: Record<string, unknown>): Promise<CallToolResult> {
+    const match = qualifiedName.match(/^mcp:([^:]+):(.+)$/);
+    if (!match) throw new Error(`not an MCP-qualified tool name: ${qualifiedName}`);
+    const [, server, tool] = match;
+    const client = this.clients.get(server);
+    if (!client) throw new Error(`unknown MCP server: ${server}`);
+    return await client.callTool(tool, args);
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all(Array.from(this.clients.values()).map((c) => c.disconnect()));
+    this.clients.clear();
+    this.tools = [];
+  }
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,0 +1,148 @@
+/**
+ * MCP wire-protocol types (subset — what Lyrie needs).
+ *
+ * Source of truth: https://modelcontextprotocol.io/specification
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+// ─── Transport definitions ───────────────────────────────────────────────────
+
+export interface StdioTransport {
+  type: "stdio";
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+export interface HttpTransport {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type Transport = StdioTransport | HttpTransport;
+
+// ─── JSON-RPC base ───────────────────────────────────────────────────────────
+
+export interface JsonRpcRequest<P = unknown> {
+  jsonrpc: "2.0";
+  id: number | string;
+  method: string;
+  params?: P;
+}
+
+export interface JsonRpcNotification<P = unknown> {
+  jsonrpc: "2.0";
+  method: string;
+  params?: P;
+}
+
+export interface JsonRpcResponse<R = unknown, E = unknown> {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  result?: R;
+  error?: { code: number; message: string; data?: E };
+}
+
+// ─── MCP method shapes (subset) ──────────────────────────────────────────────
+
+export interface InitializeParams {
+  protocolVersion: string;
+  capabilities: ClientCapabilities;
+  clientInfo: { name: string; version: string };
+}
+
+export interface ClientCapabilities {
+  experimental?: Record<string, unknown>;
+  sampling?: Record<string, unknown>;
+  roots?: { listChanged?: boolean };
+}
+
+export interface ServerCapabilities {
+  experimental?: Record<string, unknown>;
+  logging?: Record<string, unknown>;
+  prompts?: { listChanged?: boolean };
+  resources?: { subscribe?: boolean; listChanged?: boolean };
+  tools?: { listChanged?: boolean };
+}
+
+export interface InitializeResult {
+  protocolVersion: string;
+  capabilities: ServerCapabilities;
+  serverInfo: { name: string; version: string };
+  instructions?: string;
+}
+
+export interface Tool {
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+}
+
+export interface ListToolsResult {
+  tools: Tool[];
+  nextCursor?: string;
+}
+
+export interface CallToolParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+export interface CallToolResult {
+  content: Array<TextContent | ImageContent | ResourceContent>;
+  isError?: boolean;
+}
+
+export interface TextContent {
+  type: "text";
+  text: string;
+}
+export interface ImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+export interface ResourceContent {
+  type: "resource";
+  resource: { uri: string; mimeType?: string; text?: string; blob?: string };
+}
+
+export interface Resource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+export interface ListResourcesResult {
+  resources: Resource[];
+  nextCursor?: string;
+}
+
+// ─── Lyrie config shapes ─────────────────────────────────────────────────────
+
+export interface McpServerConfig {
+  /** Human name used in tool prefixes (e.g. "filesystem") */
+  name?: string;
+  /** stdio transport */
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  /** http/sse transport */
+  url?: string;
+  headers?: Record<string, string>;
+  transportType?: "stdio" | "http" | "sse";
+  /** Optional per-server allow/deny lists */
+  allowTools?: string[];
+  denyTools?: string[];
+  /** Disable a server without removing the config entry */
+  disabled?: boolean;
+}
+
+export interface McpConfigFile {
+  mcpServers: Record<string, McpServerConfig>;
+}

--- a/scripts/pairing.ts
+++ b/scripts/pairing.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+/**
+ * lyrie pairing — operator CLI for DM pairing approvals
+ *
+ * Usage:
+ *   bun run scripts/pairing.ts list
+ *   bun run scripts/pairing.ts approve <channel> <code>
+ *   bun run scripts/pairing.ts revoke  <channel> <senderId>
+ *
+ * Operates on the same JSON store the gateway uses (~/.lyrie/pairing.json).
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { DmPairingManager } from "../packages/gateway/src/security/dm-pairing";
+
+const args = process.argv.slice(2);
+const cmd = args[0];
+
+const m = new DmPairingManager();
+
+function usage(): never {
+  console.error("Usage:");
+  console.error("  lyrie pairing list");
+  console.error("  lyrie pairing approve <channel> <code>");
+  console.error("  lyrie pairing revoke  <channel> <senderId>");
+  process.exit(2);
+}
+
+switch (cmd) {
+  case "list": {
+    const store = m.list();
+    console.log("\nPending:");
+    if (store.pending.length === 0) console.log("  (none)");
+    for (const p of store.pending) {
+      console.log(
+        `  - ${p.channel}  ${p.senderId} (${p.senderName ?? "unknown"})  code=${p.code}  requested=${p.requestedAt}`,
+      );
+    }
+    console.log("\nApproved:");
+    if (store.approved.length === 0) console.log("  (none)");
+    for (const a of store.approved) {
+      console.log(
+        `  - ${a.channel}  ${a.senderId} (${a.senderName ?? "unknown"})  approved=${a.approvedAt}`,
+      );
+    }
+    console.log("");
+    break;
+  }
+  case "approve": {
+    const channel = args[1] as any;
+    const code = args[2];
+    if (!channel || !code) usage();
+    const r = m.approve(channel, code);
+    if (!r) {
+      console.error(`✗ No pending pairing for channel=${channel} code=${code}`);
+      process.exit(1);
+    }
+    console.log(`✅ Approved ${channel} ${r.senderId} (${r.senderName ?? "unknown"})`);
+    break;
+  }
+  case "revoke": {
+    const channel = args[1] as any;
+    const senderId = args[2];
+    if (!channel || !senderId) usage();
+    const ok = m.revoke(channel, senderId);
+    if (!ok) {
+      console.error(`✗ No approved pairing for channel=${channel} sender=${senderId}`);
+      process.exit(1);
+    }
+    console.log(`✅ Revoked ${channel} ${senderId}`);
+    break;
+  }
+  default:
+    usage();
+}


### PR DESCRIPTION
## Phase 1 — Subset C (DM pairing + MCP)

Two additive upgrades from the absorption roadmap. Both default-off, both back-compatible.

Roadmap: `lyrie/research/integration/lyrie-absorption-roadmap-2026-04-27.md`

---

### 1. DM Pairing Policy (OpenClaw absorption)

Three modes per channel: `open` (default, back-compat), `pairing`, `closed`.

```bash
# operator approves pairing requests
bun run pairing list
bun run pairing approve telegram ABCD-EFGH
bun run pairing revoke  telegram 1780375318
```

Files:
- `packages/gateway/src/security/dm-pairing.ts` — DmPairingManager + evaluateDmPolicy
- `packages/gateway/src/common/router.ts` — additive middleware gate
- `packages/gateway/src/common/types.ts` — `dmPolicy` field added
- `scripts/pairing.ts` — operator CLI
- 11 unit tests in `dm-pairing.test.ts`, all pass

Env vars (all optional, defaults preserve current behavior):
- `LYRIE_TELEGRAM_DM_POLICY`, `LYRIE_WHATSAPP_DM_POLICY`, `LYRIE_DISCORD_DM_POLICY`
- `LYRIE_WHATSAPP_USERS`, `LYRIE_DISCORD_USERS`

Storage: `~/.lyrie/pairing.json` (mode 0600, JSON, no SQLite/native deps).

---

### 2. MCP Adapter (Gemini CLI / Cline / Claude Code parity)

New `@lyrie/mcp` workspace package. Lyrie can now connect to any MCP server (filesystem, github, postgres, slack, etc) and use their tools.

```bash
# list available MCP tools from configured servers
bun run mcp list

# call one
bun run mcp call filesystem read_file '{"path":"/tmp/hello.txt"}'
```

Config at `~/.lyrie/mcp.json`:
```json
{
  "mcpServers": {
    "filesystem": {
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
    }
  }
}
```

Files:
- `packages/mcp/src/types.ts` — wire-protocol types
- `packages/mcp/src/client.ts` — stdio + http/sse JSON-RPC client
- `packages/mcp/src/registry.ts` — config loader + tool aggregator
- `packages/mcp/src/index.ts` — public exports + CLI
- 7 unit tests in `registry.test.ts`, all pass
- README + package.json

---

### Verification
- `bun test` → **18/18 pass** (11 pairing + 7 MCP)
- `bun run pairing list` → clean output
- `bun run mcp list` → "no servers connected" when none configured (correct)
- TypeScript: zero new errors. Pre-existing UI/skill TS noise unchanged.

### Diff: +1457 / -1 / 0 deletions

| File | Lines |
|---|---:|
| packages/mcp/src/client.ts | +304 |
| packages/gateway/src/security/dm-pairing.ts | +269 |
| packages/mcp/src/types.ts | +148 |
| packages/gateway/src/security/dm-pairing.test.ts | +145 |
| packages/mcp/src/registry.ts | +132 |
| packages/mcp/src/registry.test.ts | +85 |
| scripts/pairing.ts | +76 |
| packages/mcp/README.md | +74 |
| packages/mcp/src/index.ts | +72 |
| packages/gateway/src/common/router.ts | +44 |
| packages/gateway/src/index.ts | +32 |
| packages/mcp/package.json | +30 |
| CHANGELOG.md | +21 |
| packages/gateway/src/common/types.ts | +21 |
| package.json | +5/-1 |