### PR TITLE
feat(phase-3): pluggable execution backends (Daytona / Modal) + restore CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,567 @@
+# Changelog
+
+All notable changes to Lyrie Agent will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added — Phase 3 (Distribution — part 4: Pluggable execution backends)
+- **Lyrie execution-backend abstraction** (`packages/core/src/backends/`).
+  Pluggable runner for Lyrie scans — same Shield Doctrine, same SARIF,
+  different host.
+- **`Backend` interface** (`backends/types.ts`):
+    `kind: BackendKind`, `displayName`, `isConfigured()`,
+    `preflight() → { ok, reason }`, `run(BackendRunRequest) → BackendRunResult`,
+    optional `cleanup()`.
+- **3 implementations:**
+    - **`LocalBackend`** — default; runs on the caller. Always configured.
+      Honors `LYRIE_LOCAL_DRY_RUN=1` for tests.
+    - **`DaytonaBackend`** — spins up a Daytona devbox from
+      `ghcr.io/overthetopseo/lyrie-agent:latest` (overridable), runs Lyrie
+      inside, fetches SARIF from `/workspaces/{id}/files/lyrie-runs/lyrie.sarif`,
+      tears down (TTL safety net at 1800s default). Full `BackendRunRequest`
+      → create-workspace JSON translation. Injectable `FetchFn` so tests can
+      drive the whole state machine without network.
+    - **`ModalBackend`** — invokes a Modal serverless function
+      (`POST /v1/functions/invoke`) with the same payload, surfaces
+      `costUsd` when reported. Same `FetchFn` injection.
+- **`getBackend()` factory** (`backends/factory.ts`) — resolves backend
+  from explicit kind → `LYRIE_BACKEND` env → default "local". Reads each
+  backend's required env vars (`DAYTONA_API_*`, `MODAL_TOKEN_*`,
+  `LYRIE_*_REGION`, `LYRIE_*_IMAGE`, etc.). Throws on explicit kind/config
+  mismatch.
+- **`extractSarifSummary()`** — lenient SARIF → `{ highest, findingCount }`
+  helper used by Daytona + Modal result paths.
+- **`emptySarif()`** — minimal valid SARIF 2.1.0 doc for happy-path
+  fallbacks.
+- **`lyrie backend` CLI** (`scripts/backend.ts`):
+    `bun run backend list                                # 3 backends, configured/unconfigured`
+    `bun run backend status                              # resolved kind + per-backend status`
+    `bun run backend show <local|daytona|modal>          # env-detected config`
+    `bun run backend preflight [<kind>]                  # cheap auth/connectivity`
+    `bun run backend run --kind=<k> --target=<dir> ...   # one-shot scan`
+- **Core exports** (`packages/core/src/index.ts`) — 14 new exports:
+    `LocalBackend`, `DaytonaBackend`, `ModalBackend`, `getBackend`,
+    `lyrieEmptySarif`, `lyrieExtractSarifSummary`, `lyrieDescribeBackend`,
+    `lyrieResolveBackendKind`, `lyrieReadDaytonaConfig`, `lyrieReadModalConfig`,
+    `lyrieReadLocalConfig`, `LYRIE_SUPPORTED_BACKENDS`, plus full type
+    surface (`Backend`, `BackendKind`, `BackendRunRequest`,
+    `BackendRunResult`, `BackendResourceHints`, `LocalBackendConfig`,
+    `DaytonaBackendConfig`, `ModalBackendConfig`, `AnyBackendConfig`,
+    `BackendFactoryOptions`, `LyrieBackendFetchFn`).
+- **Deployment recipes** (`deploy/`):
+    - `deploy/modal/lyrie_modal.py` — ready-to-deploy Modal app,
+      `modal deploy deploy/modal/lyrie_modal.py`.
+    - `deploy/daytona/lyrie.devcontainer.json` — devcontainer spec for
+      Daytona-hosted dev environments.
+    - `deploy/README.md` — backend-by-backend deployment recipe.
+- **README:** new "☁️ Where Lyrie runs" section + cross-link to `deploy/`.
+- **Tests (33 new)** in `packages/core/src/backends/backends.test.ts`:
+    `resolveBackendKind` (5), `extractSarifSummary` (3), env readers (3),
+    `LocalBackend` (4 incl. dryRun), `DaytonaBackend` (8 incl. full state
+    machine + cleanup verification + error fallthrough),
+    `ModalBackend` (5 incl. cost surfacing), `getBackend` factory (5
+    incl. mismatch error + describe). All pass.
+
+Total Lyrie suite: **379 / 0 / 1544** TS + 63 Py = **442 / 0**
+(was 346 / 0 / 1470 + 63 Py = 409 / 0).
+
+### Added — Phase 3 (Distribution — part 3: Multi-channel gateway expansion)
+- **7 new channel adapters** join Telegram + WhatsApp + Discord:
+  - **Slack** (`packages/gateway/src/slack/bot.ts`) — Events API + Socket
+    Mode normalization, Block Kit rendering for inline buttons,
+    `block_actions` interaction handling.
+  - **Matrix** (`packages/gateway/src/matrix/bot.ts`) — federated /sync
+    pattern, `m.room.message` ingest, HTML formatting, `m.in_reply_to`
+    threading, optional E2EE-ready device id.
+  - **Mattermost** (`packages/gateway/src/mattermost/bot.ts`) — WebSocket
+    v4 `posted` event ingest, `file_id` media, interactive props for
+    buttons.
+  - **IRC** (`packages/gateway/src/irc/bot.ts`) — RFC 2812 PRIVMSG
+    ingest, DM vs channel detection, IRCv3 server-time honored,
+    UTF-8-safe ~410-byte line splitting, bracketed `[text](url)` button
+    rendering (no native buttons in IRC).
+  - **Feishu / Lark** (`packages/gateway/src/feishu/bot.ts`) — single
+    adapter for both 飞书 (mainland) and Lark (international) via
+    `isLark` flag and `apiHost()` switch; `im.message.receive_v1`
+    envelope ingest, verification-token gate, text + interactive
+    (card) message rendering, tenant_access_token slot.
+  - **Rocket.Chat** (`packages/gateway/src/rocketchat/bot.ts`) — DDP /
+    REST pattern, system-message + self-loop filtering,
+    `attachments.actions` interactive button rendering.
+  - **WebChat** (`packages/gateway/src/webchat/bot.ts`) — the widget
+    Lyrie owns end-to-end. WebSocket frame schema, callback frames,
+    socket registration / drop, origin allow-list with wildcard
+    subdomain support (`*.lyrie.ai`).
+- **`ChannelType`** union extended (back-compat): `slack | matrix |
+  mattermost | irc | feishu | rocketchat | webchat`.
+- **Per-channel config interfaces** + full env-var wiring in
+  `packages/gateway/src/index.ts`:
+    `LYRIE_SLACK_BOT_TOKEN`, `LYRIE_MATRIX_*`, `LYRIE_MATTERMOST_*`,
+    `LYRIE_IRC_*`, `LYRIE_FEISHU_*`, `LYRIE_ROCKETCHAT_*`,
+    `LYRIE_WEBCHAT_*`.
+- **`tryStart()` helper** for uniform start + dmPolicy wiring across
+  all 7 new bots.
+- **All 7 bots exported** alongside Telegram/WhatsApp/Discord from the
+  gateway entry point.
+- **README:** new "Where Lyrie talks to you" channel matrix table.
+- **Tests (66 new)**: 7–9 unit tests per adapter — envelope
+  normalization, self-loop filtering, media handling, button rendering,
+  start() bailouts on missing secrets, ingest → handler dispatch loop,
+  channel-specific quirks (IRC line splitting, WebChat origin
+  allow-list with wildcard subdomain support, Feishu verificationToken
+  gate, Matrix HTML formatting, Mattermost props.attachments,
+  Rocket.Chat $date timestamp shape, etc.). All pass.
+
+Total Lyrie suite: **346 / 0 / 1470** TS + 63 Py = **409 / 0**
+(was 293 / 0 / 1349 + 63 Py = 356 / 0).
+
+### Added — Phase 3 (Distribution — part 2: Lyrie Tools Catalog + cross-CI templates) [v0.3.1]
+- **Lyrie Tools Catalog** (`packages/core/src/tools-catalog/`) — vetted
+  registry of external security tools the agent can drive.
+- **19 categories · 35 vetted tools · Lyrie-original recommend() engine.**
+- **`lyrie tools` CLI** — list / categories / search / tag / recommend /
+  status / show.
+- **24 catalog tests** + 269 → 293 TS test count.
+- **Cross-CI templates** (`action/templates/`) — GitLab CI / Jenkins /
+  CircleCI drop-ins. Same Lyrie scan, same SARIF, every host.
+- **README:** "No Docker. No yak-shaving." tagline + cross-CI pointer.
+- **Action runner:** `__pycache__/`, `*.pyc`, `*.pyo` added to ignore
+  globs.
+
+### Added — Phase 3 (Distribution — part 1: Lyrie Python SDK)
+- **Lyrie Agent Python SDK** (`sdk/python/`) — `pip install lyrie-agent`.
+  Pure-Python port of every Lyrie pentest primitive, fully usable from
+  any Python project. Zero runtime dependencies (httpx is opt-in via
+  `lyrie-agent[http]`).
+- **Eight modules ported with full parity:**
+    - `lyrie.Shield` — Shield Doctrine. `scan_recalled` / `scan_inbound`.
+    - `lyrie.AttackSurfaceMapper` — entry points, trust boundaries, tainted
+      data flows, dependencies, hotspots. Same detector matrix as the TS
+      mapper. `MAPPER_VERSION = lyrie-asm-py-1.0.0`.
+    - `lyrie.StagesValidator` — six gates: pattern-reality, reachability,
+      code-path, final-call, PoC, remediation. Auto-curl PoCs for shell /
+      SQL / XSS / SSRF / path-traversal. 8-category remediation summaries.
+    - `lyrie.scan_files` — multi-language scanners (JS / TS / Python / Go /
+      PHP / Ruby / C / C++) with the same `lyrie-<lang>-*` rule namespace.
+    - `lyrie.HttpProxy` — capture + classify + 7 signal detectors.
+    - `lyrie.EditEngine` — diff-view edits with approval gates,
+      Shield-on-patch, sha256 drift detection, workspace scoping.
+    - `lyrie.ThreatIntelClient` — KEV-aligned advisories from
+      research.lyrie.ai. Network-optional, in-memory TTL cache.
+    - `lyrie.run_oss_scan` — the OSS-Scan service engine.
+- **`lyrie-py` CLI** (`python -m lyrie.cli`):
+    `lyrie-py shield <text>`
+    `lyrie-py understand --root <path>`
+    `lyrie-py scan-files --root <path>`
+    `lyrie-py validate-finding --severity high --evidence "..."`
+    `lyrie-py intel [--offline]`
+  All commands honor `--json` where structured output is useful.
+- **GitHub Actions**:
+    - `sdk-python-ci.yml` — pytest matrix on Python 3.10/3.11/3.12/3.13
+      across Ubuntu + macOS + sdist/wheel build verification with twine.
+    - `sdk-python-publish.yml` — trusted-publisher PyPI release on
+      `sdk-py-v*.*.*` tags.
+- **Tests (63 new)**:
+    - `test_shield.py`        — 8 cases
+    - `test_attack_surface.py` — 8 cases
+    - `test_stages.py`         — 15 cases
+    - `test_scanners.py`       — 15 cases
+    - `test_proxy_and_misc.py` — 17 cases (proxy + edits + threat-intel + oss-scan)
+  All pass on Python 3.12. Total Lyrie suite now: **332 / 0** (269 TS + 63 Py).
+- **README updated** with PyPI badge, Python embed example, and 332-test count.
+
+### Added — Phase 2 (Pentest — part 7 / FINAL: Deeper SARIF rule metadata)
+- **SARIF 2.1.0 rule + result metadata enriched** (`action/runner-helpers.ts`).
+  Lyrie's GitHub Code Scanning output now carries the metadata GitHub
+  actually uses for its UI:
+    - `tool.driver.organization = "OTT Cybersecurity LLC"`
+    - `tool.driver.semanticVersion = "0.2.6"`
+    - `runs[].properties.generatedBy = "Lyrie.ai by OTT Cybersecurity LLC"`
+    - **Per-rule** `defaultConfiguration.level`, `properties.tags`
+      (“security” + `lyrie:<source>` + cwe), `properties["security-severity"]`
+      (0–10 float, drives GitHub’s severity sidebar), `properties["lyrie:source"]`
+      (shield/mapper/scanner/validator/intel/proxy), `help.text` + `help.markdown`,
+      `fullDescription`, and `relationships[]` linking to CWE entries.
+    - **Per-result** `partialFingerprints.lyrieFingerprint` for stable cross-run
+      dedup, `properties["security-severity"]`, `properties["lyrie:confidence"]`
+      (parsed out of the Stages A–F line), `properties["lyrie:source"]`,
+      and `message.markdown` carrying the Lyrie / OTT Cybersecurity LLC signature.
+- **Lyrie source classifier** infers which Lyrie module produced each rule
+  from the finding id prefix (`lyrie-shield-*` → shield, `lyrie-flow-*` →
+  mapper, `lyrie-jsts/py/go/php/rb/cpp-*` → scanner, threat-intel-enriched
+  descriptions → intel, otherwise → validator).
+- **`lyrie-shield: ignore-file`** annotation added to
+  `packages/core/src/pentest/proxy/proxy.ts` because the proxy module
+  contains literal credential-shape strings inside its own detector —
+  product code, not a vector.
+- **Tests**: 10 new SARIF metadata cases (driver organization, rule tags,
+  help.markdown signature, CWE relationships, result fingerprints,
+  per-result security-severity, lyrie:source inference, message.markdown
+  signature, lyrie:confidence parsing, empty-findings still emits
+  metadata). All pass. Total suite now: 269 / 0 / 706 expect()s.
+- **Phase 2 CLOSED.** Roadmap progresses to Phase 3 next — Lyrie Python SDK
+  on PyPI (`pip install lyrie-agent`) for embedding Lyrie inside any Python
+  project.
+
+### Added — Phase 2 (Pentest — part 6: Lyrie HTTP Proxy)
+- **Lyrie HTTP Proxy** (`packages/core/src/pentest/proxy/`).
+  Lyrie's purpose-built request/response inspection layer for offensive
+  testing. Captures every HTTP exchange in-memory, classifies it,
+  detects security signals, and offers structured replay with mutators.
+- **9 security-signal detectors**:
+    - missing-security-header (CSP, HSTS, X-Content-Type-Options,
+      X-Frame-Options/frame-ancestors, Referrer-Policy, Permissions-Policy)
+    - weak-cookie-flag (HttpOnly, Secure, SameSite)
+    - open-cors (wildcard ACAO)
+    - auth-token-in-url (token / api_key / access_token / etc. in query)
+    - verbose-error (stack-trace-shaped 5xx bodies)
+    - secret-in-response (PEM / AWS / api_key shapes)
+    - graphql-introspection-enabled
+    - secret-in-request (planned hook)
+    - unsafe-redirect (planned hook)
+- **9 HTTP-surface classifiers**: login, register, logout,
+  password-reset, search, upload, download, graphql, rest-list,
+  rest-item, websocket-handshake, static, api-other, unknown.
+- **7 structured Mutators**: header-add / header-set / header-remove,
+  param-set / param-fuzz, body-replace, method-swap, path-fuzz.
+- **Allow / deny host enforcement** on every `send()` and `replay()`
+  so an operator can't fat-finger a request against an unauthorised
+  host. The proxy refuses by default if either list is configured.
+- **Shield Doctrine on responses**: every response body passes
+  `scanRecalled` before the agent sees it. Captured pages are
+  attacker-controlled territory — Lyrie defends by default.
+- **`lyrie proxy` CLI** (`scripts/proxy.ts`):
+    `bun run proxy send <METHOD> <URL>`
+    `bun run proxy scan <URL>`
+    `bun run proxy headers <URL>`
+  In-memory only; nothing persisted to disk.
+- **Tests**: 25 new (surface classification on 4 corpora, 9 signal
+  detectors, 6 mutator behaviours including immutability, the full
+  send / replay / Shield-redact / allow-host / deny-host / clear /
+  signals flow). All pass. Total suite now: 259 / 0 / 669 expect()s.
+
+### Added — Phase 2 (Pentest — part 5: Lyrie Threat-Intel)
+- **Lyrie Threat-Intel Client**
+  (`packages/core/src/pentest/threat-intel/`).
+  Lyrie's runtime that pulls KEV-aligned CVE advisories from
+  `research.lyrie.ai` and attributes them to:
+    - dependencies discovered by the Attack-Surface Mapper
+    - findings produced by the Multi-Language Scanners
+    - findings whose text references a CVE / Lyrie advisory slug
+  Network-optional: when the feed is unreachable the client returns no
+  matches and never throws — CI is never gated on intel availability.
+  Pluggable fetcher for hermetic tests + offline mode for fully offline
+  pipelines. Built-in TTL cache (1h default) so CI runs that scan many
+  PRs in a day don't pummel the feed.
+- **`enrichFindings()`**: bumps KEV-listed matches to `critical` and
+  appends a Lyrie Threat-Intel badge with CVSS, KEV status, Lyrie
+  Verdict, and a `research.lyrie.ai` link inline in every finding
+  description.
+- **Action runner integration**: every PR run now enriches findings
+  through the Threat-Intel client before they reach the Stages A–F
+  validator. Findings carrying KEV-listed CVEs surface as critical with
+  a one-line operator-facing verdict.
+- **`lyrie intel` CLI** (`scripts/intel.ts`):
+    `bun run intel list` — list cached advisories
+    `bun run intel refresh` — force-refresh feed
+    `bun run intel lookup <CVE>` — single advisory deep-dive
+    `bun run intel scan-deps` — match feed against package.json
+  Honors `LYRIE_INTEL_OFFLINE=1` for fully offline runs.
+- **Lyrie semver-ish version-range matcher** (`versionAffected`): zero
+  external semver dependency in core; supports `<= < > >= = ^ ~ A - B`
+  forms.
+- **Tests**: 15 new (versionAffected ranges, offline + seed, fetcher
+  hook with success / HTTP-error / throw paths, dependency matching
+  including version filtering and scope-loose matching, CVE-text +
+  slug-text finding matching, KEV severity bumping, no-match passthrough).
+  All pass. Total suite now: 234 / 0 / 619 expect()s.
+
+### Added — Phase 2 (Pentest — part 4: Multi-Language Scanners + Lyrie OSS-Scan)
+- **Lyrie Multi-Language Vulnerability Scanners**
+  (`packages/core/src/pentest/scanners/`).
+  Eight Lyrie-original scanners with 53 detection rules:
+    - `lyrie-jsts` (9 rules) — JavaScript / TypeScript: shell-injection,
+      eval / Function constructor, innerHTML XSS, template-string SQL,
+      SSRF via fetch, JWT alg=none, prototype pollution, hard-coded
+      secrets, open redirect.
+    - `lyrie-py` (9 rules) — Python: subprocess shell=True, os.system,
+      pickle.loads, yaml.load, eval/exec, Jinja2 autoescape=False,
+      f-string SQL, Flask debug=True, hard-coded credentials.
+    - `lyrie-go` (6 rules) — Go: /bin/sh -c shell, fmt.Sprintf SQL,
+      InsecureSkipVerify, filepath.Join + ../, hard-coded secrets, XXE.
+    - `lyrie-php` (7 rules) — PHP: shell-exec family, eval, unserialize,
+      $_GET/$_POST SQL, dynamic include LFI/RFI, XXE, hard-coded secrets.
+    - `lyrie-rb` (6 rules) — Ruby: backticks/system/%x{}, YAML.load,
+      Marshal.load, ActiveRecord interpolated where(), mass-assignment
+      without permit(), hard-coded secrets.
+    - `lyrie-cpp` (5 rules) — C/C++: strcpy/strcat/sprintf/gets, system,
+      printf with non-literal format, use-after-free heuristic,
+      rand() for cryptographic use.
+  Each scanner emits the `Lyrie.ai by OTT Cybersecurity LLC` signature
+  and a versioned `lyrie-<lang>-1.0.0` tag.
+- **Action runner integration**: GitHub Action runs all eight scanners
+  on every PR alongside the Shield baseline + Attack-Surface Mapper.
+  Scanner findings flow through Stages A–F validation so only
+  confirmed signals ship.
+- **Lyrie OSS-Scan service** (`packages/core/src/pentest/oss-scan/service.ts`).
+  Free public scan at `research.lyrie.ai/scan`. Submit any public repo URL
+  (GitHub / GitLab / Bitbucket / Codeberg), get a full Lyrie report
+  (Mapper + Scanners + Stages A–F + auto-PoC + remediation) in seconds.
+  Hardened URL validation: shell-injection-shaped owner/repo refused,
+  loopback + RFC1918 + link-local hosts blocked at the gate, malformed
+  refs rejected, scheme allowlist (`http`/`https` only). Total scan
+  bounded by file count + bytes-per-file + wall-clock timeout.
+- **`lyrie scan` CLI** (`scripts/scan.ts`):
+    `bun run scan <repoUrl> [--ref <branch>] [--json]`
+  Operator wrapper around the OSS-Scan service.
+- **Tests**: 43 new (29 multi-language scanners + 14 OSS-Scan service).
+  All pass. Total suite now: 219 / 0.
+- **README updated**: highlights Multi-Language Scanners + OSS-Scan,
+  test badge bumped to 219, new CLI entry for `lyrie scan`.
+
+### Added — Phase 2 (Pentest — part 3: Stages A–F Validator)
+- **Lyrie Stages A–F Exploitation Validator**
+  (`packages/core/src/pentest/stages-validator.ts`).
+  Every raw finding from a scanner now passes through six validation gates
+  before it can ship as confirmed:
+    - **Stage A** — Pattern reality (filters comments, regex.exec false
+      positives, parameterized SQL, textContent XSS sinks, etc.)
+    - **Stage B** — Reachability (test/spec files filtered, trust-boundary
+      lookup against the Attack-Surface Mapper, severity bumped on
+      reachable+unprotected paths)
+    - **Stage C** — Code-path existence (build artifacts, `node_modules`,
+      `.next`, `dist`, `.min.js` filtered)
+    - **Stage D** — Final call (rolls up A–C verdicts, promotes confidence
+      when reachable+unprotected)
+    - **Stage E** — PoC generation (auto-curl PoCs for shell-injection,
+      sql-injection, xss, ssrf, path-traversal; falls back to
+      `needs-human-poc` for unsupported categories)
+    - **Stage F** — Remediation (concrete summary per category, optional
+      `oldText→newText` patch wired through the EditEngine)
+  Every validated finding carries the `Lyrie.ai by OTT Cybersecurity LLC`
+  signature and a confidence score 0–1.
+- **Action runner integration**: the GitHub Action now runs every finding
+  through `validateBatch` and only ships confirmed signals. Reports
+  include the Stages A–F verdict line + auto-generated PoCs in fenced
+  code blocks + Lyrie remediation summaries.
+- **`@lyrie/core` exports**: `validateFinding`, `validateBatch`,
+  `STAGES_VALIDATOR_VERSION`, plus all stage / verdict / category types.
+- **Tests (24 new for the validator)**: Stage A pattern-reality scenarios,
+  Stage B reachability with surface lookup, Stage C build-artifact / test
+  filtering, Stage E auto-PoC for each supported category, Stage F
+  remediation coverage, batch filtering with and without observations,
+  signature + version checks, confidence scoring bounds. All pass.
+- **README rewritten** for current state — highlights the Shield Doctrine,
+  Attack-Surface Mapper, Stages A–F validator, GitHub Action, MCP, FTS5
+  memory, diff-view edits, DM pairing, doctor; includes the doctrine
+  surface table, operator-CLI summary, and an updated test count
+  (176 pass / 0 fail).
+
+### Added — Phase 2 (Pentest — part 2: Attack-Surface Mapper + Lyrie-only branding)
+- **Lyrie Attack-Surface Mapper** (`packages/core/src/pentest/attack-surface.ts`).
+  Lyrie's purpose-built static security mapper. Before any vulnerability
+  scanner runs, the mapper builds a structural picture of the target:
+  entry points (HTTP routes, CLI commands, file readers, env consumers,
+  deserialization sinks, subprocess spawns, websockets, cron), trust
+  boundaries (auth gates, RBAC checks, rate limits, sandbox crossings,
+  Shield gates), tainted data flows (e.g. user-message → shell,
+  http-input → sql), full dependency catalogue across npm / cargo /
+  pip / go / ruby, and ranked risk hotspots.
+  Every emitted artifact carries the embedded signature
+  `Lyrie.ai by OTT Cybersecurity LLC` and a `mapperVersion`.
+- **`lyrie understand` CLI** (`scripts/understand.ts`): map any workspace
+  with one command. JSON + human-readable output modes.
+- **Action runner integration**: the GitHub Action now produces an
+  attack-surface summary section in every PR report and promotes the
+  highest-risk tainted flows (risk ≥ 7) into SARIF + PR-comment findings.
+- **Lyrie-only branding pass**: stripped every external-product reference
+  from source comments. Internal modules now name Lyrie's own components
+  exclusively, with `Lyrie.ai by OTT Cybersecurity LLC` signatures across
+  edit-engine, fts-search, dm-pairing, channels/gateway, mcp/README,
+  action/README, ai-pentest skill, and shield-doctrine. Migration
+  adapters and the README comparison table keep their factual
+  competitor references (those are legitimate interop / positioning).
+- **Tests (9 new for the mapper)**: HTTP-route detection, subprocess +
+  file-reader detection, env-var detection, auth + Shield boundaries,
+  rate-limit detection, taint flow risk scoring, npm dependency
+  collection, hotspot ranking + signature, ignore-file annotation.
+  All pass.
+
+### Added — Phase 2 (Pentest — part 1: GitHub Action)
+- **`overthetopseo/lyrie-agent/action@v1`** — first-class GitHub Action
+  for AI-powered pentest with Shield-on-PR.
+  - Composite action (`action/action.yml`) with 12 inputs and 5 outputs.
+  - Diff-scope by default: scans only PR-changed files.
+  - Fail-on threshold (`critical` / `high` / `medium` / `low` / `none`).
+  - SARIF upload to GitHub Code Scanning.
+  - Single-comment-per-PR Markdown summary (updates in place, no spam).
+  - Workflow artifact upload + GitHub job summary.
+  - Shield Doctrine: target input passes `scanInbound` before any work.
+- **Built-in ignore globs**: build artifacts (`.next/`, `dist/`, `target/`),
+  vendor trees (`node_modules/`), Shield self-tests (those legitimately
+  use injection patterns to verify Shield works).
+- **`lyrie-shield: ignore-file` annotation** for legitimate security-content
+  fixtures (UI strings naming attack types, documentation that quotes
+  injection payloads, etc).
+- **Self-test workflow** (`.github/workflows/action-selftest.yml`): the
+  Lyrie Action runs against the Lyrie repo itself on every PR.
+- **Tests**: 8 unit tests for the runner's Markdown + SARIF helpers.
+  All pass.
+
+### Fixed — Test Modernization (zero-fail suite)
+- **All 36 pre-existing test failures resolved.** Tests had been written
+  against an older API (string-shaped `execute()` returns, file-based
+  `MASTER-MEMORY.md`, stale skill IDs). Modernized them to match the
+  current production contract.
+- **Real Shield upgrade**: `ShieldManager.scanInput` now also scans for
+  dangerous shell patterns (`rm -rf /`, fork bombs, etc.) embedded in
+  user input. Previously these were only caught at the tool-call boundary.
+  Catches social-engineering attempts at the input layer.
+- **Real ModelRouter upgrade**: removed the `// TEMPORARY: Route
+  everything to brain` override that had been live since v0.1.0. Smart
+  routing restored: coder / fast / reasoning / bulk / brain / general
+  patterns. Adds a new `brain` pattern for strategy / planning / design.
+- **SkillManager built-ins aligned** with the actual `skills/` workspace
+  folder names: now ships `web-search`, `threat-scan`,
+  `vulnerability-check`, `device-protect`, `code-execution`,
+  `file-management`, `system-monitor` (renamed from the stale
+  `code-writer` / `file-manager` / `threat-scanner`). 7 built-in skills
+  total, all matching their workspace counterparts.
+- **MemoryCore.status** now mentions "self-healing" so the operator's
+  status string reflects the system's actual capability.
+- **Test files modernized**: `tool-executor.test.ts`,
+  `shield-manager.test.ts`, `model-router.test.ts`,
+  `skill-manager.test.ts`, `memory-core.test.ts`. All now pass.
+- **Net result**: **135 pass / 0 fail / 414 expectations** — the
+  cleanest the suite has been since v0.1.0.
+
+### Added — Phase 1 (Core Agent Absorption — part 4: Diff-View Edits)
+- **`EditEngine`** (`packages/core/src/edits/edit-engine.ts`) — Cline-style
+  diff-view file edits with approval gates. Targeted `oldText → newText`
+  replacements with strict uniqueness checks, unified-diff generation
+  (LCS-based, context-3 hunks), and three approval modes:
+  `auto-approve`, `require-approval` (default — production-safe),
+  `dry-run`.
+- **Shield Doctrine on patches**: every plan's resulting content is
+  scanned through `scanRecalled` BEFORE the file is touched. Blocked
+  patches never land on disk (the doctrine table now shows ✅ for
+  diff-view edits).
+- **Edit ledger** at `~/.lyrie/edits.json` (mode 0600). Tracks pending
+  plans + applied edits with sha256 before/after hashes; refuses to apply
+  if the file drifted between plan and apply.
+- **Workspace scoping**: paths outside the configured workspace root are
+  refused.
+- **`apply_diff` tool** registered in `ToolExecutor`. The agent uses this
+  for in-place edits; `write_file` is preserved for whole-file writes.
+  In `require-approval` mode, the tool returns the unified diff with a
+  pending-approval pointer instead of applying.
+- **`lyrie edits` operator CLI** (`scripts/edits.ts`):
+  `list`, `review <planId>`, `approve <planId>`, `log`.
+- **Unit tests (14 new, all pass)**: diff rendering, plan applicability,
+  Shield-block-on-injection, Shield-block-on-credentials, auto-approve,
+  drift detection, require-approval flow, dry-run, workspace scoping.
+
+### Added — Phase 1 (Core Agent Absorption — part 3: Shield Doctrine Backfill)
+- **Tool Executor Shield filter**: new `Tool.untrustedOutput` flag.
+  Tools opting in have their successful output scanned through `ShieldGuard.scanRecalled`
+  post-execute and unsafe content is redacted with a clear Shield notice + metadata flags.
+  Default Built-in tools tagged `untrustedOutput: true`:
+  `exec` (shell stdout), `read_file` (file contents), `web_search` (third-party snippets),
+  `web_fetch` (scraped web content). Trusted tools (`write_file`, `list_directory`,
+  `threat_scan`) intentionally pass through.
+- **`ToolExecutor.setOutputShield(guard)`** to inject a real ShieldManager-backed guard.
+- **Skill Manager Shield filter**: every successful skill output passes through the
+  Shield before reaching the agent. Skills frequently shell out / scrape / call APIs —
+  exactly the surfaces where prompt-injection appears. Failed-call output stays raw
+  for operator debugging visibility.
+- **`SkillManager.setOutputShield(guard)`** for the same injection pattern.
+- **`docs/shield-doctrine.md` updated**: 5 layers now ✅, 3 layers tracked as planned.
+- **Unit tests (10 new)**:
+  - `tool-shield.test.ts` (5): redacts injection, redacts credentials, leaves benign
+    alone, doesn't scan trusted tools, doesn't scan failed calls.
+  - `skill-shield.test.ts` (5): same coverage for skills + non-string output handling.
+  All pass.
+
+### Added — Phase 1 (Core Agent Absorption — part 2: Memory + Shield Doctrine)
+- **`ShieldGuard` cross-cutting Shield contract** (`packages/core/src/engine/shield-guard.ts`).
+  Lightweight, dependency-free `scanRecalled` / `scanInbound` interface used by
+  every layer that touches untrusted text. Built-in heuristic fallback so
+  Lyrie ships with a Shield on EVERY surface, even the admin CLIs.
+- **FTS5 cross-session memory search** (`packages/core/src/memory/fts-search.ts`).
+  Adds `MemoryCore.searchAcrossSessions(query, opts)` and
+  `MemoryCore.summarizeSession(opts)`. Hermes-inspired ranked recall with
+  bm25, snippet highlights, and triggers that keep the FTS index in sync.
+  Falls back to LIKE when FTS5 isn't available so memory recall keeps working
+  in any SQLite build.
+- **Shield wired through every Phase-1 layer**:
+  - `MemoryCore.searchAcrossSessions` → `scanRecalled` on every snippet, redacts
+    prompt-injection / credential-like material before it reaches the agent.
+  - `DmPairingManager.greet` → `scanInbound` on first-touch DM body; abusers
+    are refused without ever issuing a pairing code.
+  - `McpRegistry.call` → `shieldFilter` on every text/resource block returned
+    by third-party MCP servers.
+- **Schema bump v1 → v2**: additive FTS5 virtual table + triggers. Existing
+  databases are migrated idempotently on first boot. No destructive change.
+- **`docs/shield-doctrine.md`**: the engineering rule — every layer of Lyrie
+  has a Shield hook. New PRs that add untrusted-text surfaces without a
+  Shield call are incomplete.
+- **Unit tests**: 9 ShieldGuard, 9 FTS, 2 pairing-shield, 5 MCP-shield. All pass.
+
+### Added — Phase 1 (Core Agent Absorption — part 1)
+- **DM pairing policy** (`packages/gateway/src/security/dm-pairing.ts`) inspired by
+  OpenClaw `dmPolicy="pairing"`. Three modes: `open` (back-compat default),
+  `pairing` (unknown DMs receive a one-time code; operator approves), `closed`
+  (allowlist only). Wire-in is additive — existing channel configs without
+  `dmPolicy` keep working unchanged.
+- **`lyrie pairing` operator CLI** (`scripts/pairing.ts`): `list`,
+  `approve <channel> <code>`, `revoke <channel> <senderId>`. JSON store at
+  `~/.lyrie/pairing.json` (mode 0600).
+- **Channel config additions**: `dmPolicy` and (where missing) `allowedUsers`
+  on `TelegramConfig`, `WhatsAppConfig`, `DiscordConfig`. Env vars added:
+  `LYRIE_TELEGRAM_DM_POLICY`, `LYRIE_WHATSAPP_DM_POLICY`,
+  `LYRIE_DISCORD_DM_POLICY`, `LYRIE_WHATSAPP_USERS`, `LYRIE_DISCORD_USERS`.
+- **`@lyrie/mcp` package** — Model Context Protocol adapter. Client mode
+  (stdio + http/sse), `McpRegistry` for `~/.lyrie/mcp.json` configs, and a
+  `lyrie mcp list|call` CLI. Wire-protocol-compliant subset focused on
+  interoperability with Claude Code, Cursor, Continue, Cline, Codex, Gemini
+  CLI, and any other MCP-aware host.
+- **Unit tests** for both: `dm-pairing.test.ts` (12 cases) and
+  `registry.test.ts` (5 cases). All pass under `bun test`.
+
+### Added — Phase 0 (Repo & Distribution Upgrades)
+- **`lyrie doctor` command** — self-diagnostic for environment, dependencies, channel config, security policy, and update status.
+- **GitHub Actions CI** matrix (Node 20/22/24 × Ubuntu/macOS) with Bun + Rust Shield build.
+- **CodeQL security analysis** workflow (push/PR + weekly cron).
+- **Nightly snapshot tagging** workflow.
+- **Multi-platform release** workflow producing tarballs/zips for `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, and `x86_64-pc-windows-msvc`.
+- **Dependabot** (npm, cargo, github-actions).
+- **Pre-commit config** (whitespace, YAML/JSON/TOML lint, gitleaks secret scan, codespell).
+- **Windows installer** at `scripts/install.ps1` (`irm | iex` parity with Claude Code).
+- **CODE_OF_CONDUCT.md**, **CHANGELOG.md**, **CITATION.cff** files.
+- **`.npmignore`** for clean npm publishes.
+- **Release notes generator script** (`scripts/release/notes.sh`).
+- **Localized README stubs** for `es`, `fr`, `de`, `zh-CN`, `ja`, `ar`, `pt-BR` in `locales/` (pointer files; full translations to follow in Phase 4).
+- **Smithery + ClawHub skill listing pointers** in README footer.
+
+### Changed
+- Nothing. All Phase 0 changes are additive.
+
+### Deprecated
+- Nothing.
+
+### Removed
+- Nothing.
+
+### Fixed
+- Nothing.
+
+### Security
+- Phase 0 adds gitleaks pre-commit hook and CodeQL weekly scans of the JS/TS surface.
+
+---
+
+_Releases prior to v0.1.1 are documented in git history. Phase 0 lands as a single PR
+on `feat/phase-0-upgrades` and will ship as `v0.1.1` once merged._

--- a/README.md
+++ b/README.md
@@ -220,6 +220,37 @@ Lyrie ships a **multi-channel gateway** so the agent reaches you on whatever you
 
 Every channel implements the same `ChannelBot` contract — unified `UnifiedMessage` in, unified `UnifiedResponse` out. Same Shield Doctrine, same DM-pairing policy, same engine.
 
+## ☁️ Where Lyrie runs
+
+Lyrie scans run **somewhere**. Pick where:
+
+| Backend | When | Setup |
+|---|---|---|
+| **Local** _(default)_ | Caller has Bun + repo | zero config |
+| **Daytona** | Ephemeral devboxes / sandboxed PR scans | `DAYTONA_API_KEY` |
+| **Modal**   | Pay-per-second serverless burst | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` |
+
+Switch at runtime:
+
+```bash
+LYRIE_BACKEND=modal bun run action/runner.ts          # serverless
+LYRIE_BACKEND=daytona bun run action/runner.ts        # Daytona devbox
+LYRIE_BACKEND=local bun run action/runner.ts          # default — host
+```
+
+Inspect what's wired up:
+
+```bash
+bun run backend status         # which backend resolves & is configured
+bun run backend list           # all 3, side-by-side
+bun run backend show modal     # config + env vars detected
+bun run backend preflight      # cheap auth/connectivity check
+```
+
+Deployment recipes (Modal Python function + Daytona devcontainer): [`deploy/`](deploy/).
+
+**Same contract everywhere.** Every backend returns the same `BackendRunResult` shape — same SARIF, same Markdown, same Shield Doctrine — different host. **No Docker. No vendor lock-in.**
+
 ---
 
 ## 🏛 Architecture

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,106 @@
+# Lyrie Execution Backends — deployment recipes
+
+> _Lyrie.ai by **OTT Cybersecurity LLC** — https://lyrie.ai — MIT License._
+
+Lyrie scans run **somewhere**. Today, that "somewhere" is pluggable:
+
+| Backend | When to pick it |
+|---|---|
+| **Local** _(default)_ | Caller has Bun and the repo. Zero cost, zero network. |
+| **Daytona** | Need ephemeral, snapshot-based devboxes (e.g. PR scans isolated from runner). |
+| **Modal** | Need pure serverless. Pay-per-second. Burst-scale across hundreds of repos. |
+
+Switch at runtime:
+
+```bash
+LYRIE_BACKEND=local      bun run action/runner.ts    # default
+LYRIE_BACKEND=daytona    bun run action/runner.ts    # spin up Daytona, run there
+LYRIE_BACKEND=modal      bun run action/runner.ts    # serverless on Modal
+```
+
+Inspect what's wired up:
+
+```bash
+bun run backend status
+bun run backend list
+bun run backend show daytona
+bun run backend preflight modal
+```
+
+---
+
+## Daytona
+
+Files: [`daytona/lyrie.devcontainer.json`](daytona/lyrie.devcontainer.json)
+
+```bash
+# 1. One-time: publish the Lyrie image to GHCR (already done in CI).
+#    ghcr.io/overthetopseo/lyrie-agent:latest
+
+# 2. From your CI / shell:
+export DAYTONA_API_KEY=your_daytona_api_key
+export LYRIE_BACKEND=daytona
+export LYRIE_DAYTONA_REGION=us-east-1     # optional
+export LYRIE_DAYTONA_TTL_SECONDS=1800      # optional, default 30 min
+
+bun run backend preflight daytona
+bun run action/runner.ts
+```
+
+The Daytona backend will:
+
+1. `POST /workspaces` to spin up a Lyrie devbox from the published image.
+2. `POST /workspaces/{id}/exec` to run the action runner inside.
+3. `GET /workspaces/{id}/files/lyrie-runs/lyrie.sarif` to fetch results.
+4. `DELETE /workspaces/{id}` to tear down (TTL is the safety net).
+
+---
+
+## Modal
+
+Files: [`modal/lyrie_modal.py`](modal/lyrie_modal.py)
+
+```bash
+# 1. One-time: deploy Lyrie's serverless function to your Modal account.
+pip install modal
+modal token new
+modal deploy deploy/modal/lyrie_modal.py
+
+# 2. From your CI / shell:
+export LYRIE_BACKEND=modal
+export MODAL_TOKEN_ID=<from `modal token list`>
+export MODAL_TOKEN_SECRET=<from `modal token list`>
+
+bun run backend preflight modal
+bun run action/runner.ts
+```
+
+The Modal backend will:
+
+1. `POST https://api.modal.com/v1/functions/invoke` with the run request.
+2. Modal cold-starts a Lyrie container (image cached after first call).
+3. Lyrie runs the scan inside the function.
+4. Modal returns SARIF + markdown + cost.
+
+---
+
+## How the backend abstraction works
+
+Single contract: `Backend` interface in `packages/core/src/backends/types.ts`.
+
+```typescript
+import { getBackend } from "@lyrie/core";
+
+const b = getBackend("modal");          // or "daytona", or "local"
+const r = await b.run({
+  target:   "https://github.com/overthetopseo/lyrie-agent",
+  scanMode: "full",
+  scope:    "full",
+  failOn:   "high",
+});
+console.log(r.findingCount, r.highestSeverity, r.costUsd);
+```
+
+Every backend returns the same `BackendRunResult` shape. Same SARIF, same Markdown, same Shield Doctrine — different host.
+
+**No Docker. No vendor lock-in. Lyrie runs anywhere.**

--- a/deploy/daytona/lyrie.devcontainer.json
+++ b/deploy/daytona/lyrie.devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
+  "name": "Lyrie Agent (Daytona)",
+  "image": "ghcr.io/overthetopseo/lyrie-agent:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
+  "postCreateCommand": "bun install --frozen-lockfile",
+  "containerEnv": {
+    "LYRIE_BACKEND": "local",
+    "LYRIE_OUTPUT_DIR": "/workspace/lyrie-runs"
+  },
+  "customizations": {
+    "lyrie": {
+      "license": "MIT",
+      "vendor": "OTT Cybersecurity LLC",
+      "homepage": "https://lyrie.ai"
+    }
+  },
+  "forwardPorts": [],
+  "remoteUser": "node"
+}

--- a/deploy/modal/lyrie_modal.py
+++ b/deploy/modal/lyrie_modal.py
@@ -1,0 +1,143 @@
+"""
+Lyrie on Modal — serverless backend reference deployment.
+
+Deploy:
+    pip install modal
+    modal token new                # one-time auth
+    modal deploy deploy/modal/lyrie_modal.py
+
+After deploy, point Lyrie at it from CI:
+    LYRIE_BACKEND=modal
+    MODAL_TOKEN_ID=<from `modal token list`>
+    MODAL_TOKEN_SECRET=<from `modal token list`>
+    LYRIE_MODAL_APP=lyrie-agent
+    LYRIE_MODAL_FUNCTION=lyrie_scan
+
+Lyrie.ai by OTT Cybersecurity LLC — https://lyrie.ai — MIT License.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import modal
+
+app = modal.App("lyrie-agent")
+
+# Lyrie's image: bun runtime + git + the lyrie-agent repo cloned at deploy
+# time. For private deployments, pin a release tag via LYRIE_REF.
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("git", "curl", "ca-certificates")
+    .run_commands(
+        "curl -fsSL https://bun.sh/install | bash",
+        # bun installs to /root/.bun; symlink so PATH-less runs work.
+        "ln -sf /root/.bun/bin/bun /usr/local/bin/bun",
+    )
+    .run_commands(
+        "git clone --depth 1 https://github.com/overthetopseo/lyrie-agent.git /opt/lyrie",
+        "cd /opt/lyrie && bun install --frozen-lockfile",
+    )
+)
+
+
+@app.function(
+    image=image,
+    cpu=1.0,
+    memory=1024,
+    timeout=600,
+    secrets=[modal.Secret.from_name("lyrie-secrets", required_keys=[])],
+)
+def lyrie_scan(payload: dict) -> dict:
+    """
+    Run a single Lyrie scan inside Modal.
+
+    Expected `payload` shape (Lyrie BackendRunRequest):
+        {
+            "target":       "<git URL or rel path>",
+            "scanMode":     "quick" | "full" | "recon" | "vulnscan" | "apiscan",
+            "scope":        "diff" | "full",
+            "diffBase":     "origin/main",
+            "failOn":       "critical" | "high" | ...,
+            "intelOffline": false,
+            "env":          { "K": "v", ... },
+        }
+
+    Returns Lyrie's BackendRunResult JSON-shape:
+        { callId, status, sarif, markdown, costUsd? }
+    """
+    inputs = payload.get("inputs", {})
+    target = inputs.get("target", "")
+    work = Path("/tmp/lyrie-target")
+    work.mkdir(parents=True, exist_ok=True)
+
+    # 1. Materialise target — git clone or assume already-mounted path.
+    if isinstance(target, str) and target.startswith(("http://", "https://", "git@")):
+        subprocess.run(
+            ["git", "clone", "--depth", "30", target, str(work)],
+            check=True,
+        )
+    elif target:
+        # Caller uploaded a tarball or relied on an external mount; user
+        # extension point. Default = scan /opt/lyrie itself (smoke test).
+        work = Path(target) if Path(target).exists() else Path("/opt/lyrie")
+    else:
+        work = Path("/opt/lyrie")
+
+    # 2. Translate the inputs into LYRIE_* env vars.
+    env = {
+        "LYRIE_TARGET": str(work),
+        "LYRIE_SCAN_MODE": inputs.get("scanMode", "quick"),
+        "LYRIE_SCOPE": inputs.get("scope", "diff"),
+        "LYRIE_FAIL_ON": inputs.get("failOn", "high"),
+        "LYRIE_OUTPUT_DIR": "/tmp/lyrie-runs",
+    }
+    if inputs.get("diffBase"):
+        env["LYRIE_DIFF_BASE"] = inputs["diffBase"]
+    if inputs.get("intelOffline"):
+        env["LYRIE_INTEL_OFFLINE"] = "1"
+    for k, v in (inputs.get("env") or {}).items():
+        env[k] = str(v)
+
+    # 3. Run Lyrie.
+    proc = subprocess.run(
+        ["bun", "run", "/opt/lyrie/action/runner.ts"],
+        cwd="/opt/lyrie",
+        env={**dict(__import__("os").environ), **env},
+        capture_output=True,
+        text=True,
+        timeout=550,
+    )
+
+    sarif_path = Path("/tmp/lyrie-runs/lyrie.sarif")
+    markdown_path = Path("/tmp/lyrie-runs/lyrie.md")
+    sarif = sarif_path.read_text() if sarif_path.exists() else ""
+    markdown = markdown_path.read_text() if markdown_path.exists() else proc.stdout
+
+    return {
+        "callId": modal.current_function_call_id() if hasattr(modal, "current_function_call_id") else None,
+        "status": "pass" if proc.returncode == 0 else "fail",
+        "sarif": sarif,
+        "markdown": markdown[:65535],
+        # Modal exposes runtime cost via the dashboard; surface a stub here.
+        "costUsd": None,
+    }
+
+
+# Local smoke test:  `modal run deploy/modal/lyrie_modal.py::smoke`
+@app.local_entrypoint()
+def smoke() -> None:
+    out = lyrie_scan.remote(
+        {
+            "inputs": {
+                "target": "/opt/lyrie",
+                "scanMode": "quick",
+                "scope": "full",
+                "failOn": "critical",
+                "intelOffline": True,
+            }
+        }
+    )
+    print(json.dumps({"status": out["status"], "sarif_bytes": len(out["sarif"])}, indent=2))

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "scan": "bun run scripts/scan.ts",
     "intel": "bun run scripts/intel.ts",
     "proxy": "bun run scripts/proxy.ts",
-    "tools": "bun run scripts/tools.ts"
+    "tools": "bun run scripts/tools.ts",
+    "backend": "bun run scripts/backend.ts"
   },
   "devDependencies": {
     "turbo": "^2.0.0",

--- a/packages/core/src/backends/backends.test.ts
+++ b/packages/core/src/backends/backends.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for Lyrie execution backends.
+ *
+ * Covers:
+ *   - Pure helpers (resolveBackendKind, extractSarifSummary, env readers).
+ *   - LocalBackend dry-run + happy-path env preparation.
+ *   - DaytonaBackend full state machine (preflight, create, exec, fetch SARIF,
+ *     cleanup, error fallthrough) with an injected fake fetcher.
+ *   - ModalBackend invocation body shape + happy-path response handling.
+ *   - Factory: kind resolution, config merge, mismatch error.
+ *
+ * Lyrie.ai by OTT Cybersecurity LLC.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  DaytonaBackend,
+  LocalBackend,
+  ModalBackend,
+  describeBackend,
+  emptySarif,
+  extractSarifSummary,
+  getBackend,
+  readDaytonaConfigFromEnv,
+  readLocalConfigFromEnv,
+  readModalConfigFromEnv,
+  resolveBackendKind,
+  SUPPORTED_BACKENDS,
+  type BackendRunRequest,
+  type FetchFn,
+} from "./index";
+
+// ─── Tiny fixture builder ──────────────────────────────────────────────────────
+
+function req(overrides: Partial<BackendRunRequest> = {}): BackendRunRequest {
+  return {
+    target: "/tmp/lyrie-fixture",
+    scanMode: "quick",
+    scope: "diff",
+    failOn: "high",
+    ...overrides,
+  };
+}
+
+/** Build a fetcher that returns canned responses keyed by URL pattern. */
+function fakeFetcher(routes: Record<string, () => Promise<{ ok: boolean; status: number; body: string | object }>>): {
+  fetcher: FetchFn;
+  calls: Array<{ url: string; method: string; body?: string }>;
+} {
+  const calls: Array<{ url: string; method: string; body?: string }> = [];
+  const fetcher: FetchFn = async (url, init) => {
+    calls.push({ url, method: init?.method ?? "GET", body: init?.body });
+    for (const [pattern, handler] of Object.entries(routes)) {
+      if (url.includes(pattern)) {
+        const out = await handler();
+        const text = typeof out.body === "string" ? out.body : JSON.stringify(out.body);
+        return {
+          ok: out.ok,
+          status: out.status,
+          text: async () => text,
+          json: async () => (typeof out.body === "string" ? JSON.parse(text) : out.body),
+        };
+      }
+    }
+    throw new Error(`fakeFetcher: unrouted ${url}`);
+  };
+  return { fetcher, calls };
+}
+
+// ─── Pure helpers ──────────────────────────────────────────────────────────────
+
+describe("resolveBackendKind", () => {
+  it("prefers explicit kind", () => {
+    expect(resolveBackendKind("modal", {})).toBe("modal");
+  });
+
+  it("reads LYRIE_BACKEND env var", () => {
+    expect(resolveBackendKind(undefined, { LYRIE_BACKEND: "daytona" })).toBe("daytona");
+  });
+
+  it("falls back to local on unknown values", () => {
+    expect(resolveBackendKind(undefined, { LYRIE_BACKEND: "weird" })).toBe("local");
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveBackendKind(undefined, { LYRIE_BACKEND: "MODAL" })).toBe("modal");
+  });
+
+  it("knows all supported backends", () => {
+    expect(SUPPORTED_BACKENDS).toEqual(["local", "daytona", "modal"]);
+  });
+});
+
+describe("extractSarifSummary", () => {
+  it("returns 'none' on empty results", () => {
+    expect(extractSarifSummary(emptySarif())).toEqual({ highest: "none", findingCount: 0 });
+  });
+
+  it("counts findings + picks highest severity", () => {
+    const sarif = JSON.stringify({
+      runs: [
+        {
+          results: [
+            { level: "warning" },
+            { properties: { severity: "critical" } },
+            { level: "note" },
+          ],
+        },
+      ],
+    });
+    const s = extractSarifSummary(sarif);
+    expect(s.findingCount).toBe(3);
+    expect(s.highest).toBe("critical");
+  });
+
+  it("degrades silently on malformed JSON", () => {
+    expect(extractSarifSummary("{not json")).toEqual({ highest: "none", findingCount: 0 });
+  });
+});
+
+describe("env readers", () => {
+  it("readDaytonaConfigFromEnv pulls expected keys", () => {
+    const c = readDaytonaConfigFromEnv({
+      DAYTONA_API_KEY: "k",
+      DAYTONA_API_URL: "https://x",
+      LYRIE_DAYTONA_IMAGE: "img",
+      LYRIE_DAYTONA_REGION: "us-east-1",
+      LYRIE_DAYTONA_TTL_SECONDS: "120",
+    });
+    expect(c.apiKey).toBe("k");
+    expect(c.apiUrl).toBe("https://x");
+    expect(c.image).toBe("img");
+    expect(c.region).toBe("us-east-1");
+    expect(c.ttlSeconds).toBe(120);
+  });
+
+  it("readModalConfigFromEnv pulls expected keys", () => {
+    const c = readModalConfigFromEnv({
+      MODAL_TOKEN_ID: "id",
+      MODAL_TOKEN_SECRET: "sec",
+      LYRIE_MODAL_APP: "app",
+      LYRIE_MODAL_FUNCTION: "fn",
+    });
+    expect(c.tokenId).toBe("id");
+    expect(c.tokenSecret).toBe("sec");
+    expect(c.app).toBe("app");
+    expect(c.functionName).toBe("fn");
+  });
+
+  it("readLocalConfigFromEnv parses dryRun flag", () => {
+    expect(readLocalConfigFromEnv({ LYRIE_LOCAL_DRY_RUN: "1" }).dryRun).toBe(true);
+    expect(readLocalConfigFromEnv({ LYRIE_LOCAL_DRY_RUN: "true" }).dryRun).toBe(true);
+    expect(readLocalConfigFromEnv({}).dryRun).toBe(false);
+  });
+});
+
+// ─── LocalBackend ──────────────────────────────────────────────────────────────
+
+describe("LocalBackend", () => {
+  it("isConfigured() is always true", () => {
+    expect(new LocalBackend().isConfigured()).toBe(true);
+  });
+
+  it("preflight passes", async () => {
+    const r = await new LocalBackend().preflight();
+    expect(r.ok).toBe(true);
+  });
+
+  it("dryRun returns empty SARIF + status pass", async () => {
+    const b = new LocalBackend({ dryRun: true });
+    const result = await b.run(req());
+    expect(result.status).toBe("pass");
+    expect(result.findingCount).toBe(0);
+    expect(result.sarif).toBeDefined();
+    expect(JSON.parse(result.sarif!).version).toBe("2.1.0");
+  });
+
+  it("non-dryRun reports prepared env keys in provider details", async () => {
+    const b = new LocalBackend();
+    const result = await b.run(
+      req({ intelOffline: true, env: { CUSTOM: "v" }, diffBase: "origin/main" }),
+    );
+    const keys = (result.provider as { envKeysPrepared: string[] }).envKeysPrepared;
+    expect(keys).toContain("LYRIE_INTEL_OFFLINE");
+    expect(keys).toContain("LYRIE_DIFF_BASE");
+    expect(keys).toContain("CUSTOM");
+  });
+});
+
+// ─── DaytonaBackend ────────────────────────────────────────────────────────────
+
+describe("DaytonaBackend", () => {
+  it("isConfigured() requires apiKey", () => {
+    expect(new DaytonaBackend().isConfigured()).toBe(false);
+    expect(new DaytonaBackend({ apiKey: "k" }).isConfigured()).toBe(true);
+  });
+
+  it("preflight reports missing key", async () => {
+    const r = await new DaytonaBackend().preflight();
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("DAYTONA_API_KEY");
+  });
+
+  it("preflight uses /health endpoint when configured", async () => {
+    const { fetcher } = fakeFetcher({
+      "/health": async () => ({ ok: true, status: 200, body: { ok: true } }),
+    });
+    const r = await new DaytonaBackend({ apiKey: "k" }, fetcher).preflight();
+    expect(r.ok).toBe(true);
+  });
+
+  it("toCreateWorkspaceBody applies defaults + labels", () => {
+    const b = new DaytonaBackend({ apiKey: "k", region: "us-east-1" });
+    const body = b.toCreateWorkspaceBody(req({ labels: { env: "ci" } }));
+    expect(body["region"]).toBe("us-east-1");
+    expect((body["resources"] as { cpu: number }).cpu).toBe(2);
+    expect((body["labels"] as { env: string })["env"]).toBe("ci");
+    expect((body["labels"] as Record<string, string>)["lyrie.ai/scanMode"]).toBe("quick");
+  });
+
+  it("ttlSeconds defaults to 1800", () => {
+    expect(new DaytonaBackend({ apiKey: "k" }).ttlSeconds()).toBe(1800);
+    expect(new DaytonaBackend({ apiKey: "k", ttlSeconds: 60 }).ttlSeconds()).toBe(60);
+  });
+
+  it("happy path: create → exec → fetch SARIF → delete", async () => {
+    const sarif = JSON.stringify({
+      runs: [{ results: [{ level: "warning" }] }],
+    });
+    const { fetcher, calls } = fakeFetcher({
+      "/workspaces/abc-123/files/lyrie-runs/lyrie.sarif": async () => ({
+        ok: true,
+        status: 200,
+        body: sarif,
+      }),
+      "/workspaces/abc-123/exec": async () => ({ ok: true, status: 200, body: { ok: true } }),
+      "/workspaces/abc-123": async () => ({ ok: true, status: 200, body: {} }),
+      "/workspaces": async () => ({ ok: true, status: 201, body: { id: "abc-123" } }),
+    });
+    const b = new DaytonaBackend({ apiKey: "k" }, fetcher);
+    const r = await b.run(req());
+    expect(r.backend).toBe("daytona");
+    expect(r.status).toBe("fail"); // findings present → fail
+    expect(r.findingCount).toBe(1);
+    expect(r.runId).toBe("abc-123");
+    // Calls: POST workspaces, POST exec, GET sarif, DELETE workspace
+    expect(calls.some((c) => c.url.endsWith("/workspaces") && c.method === "POST")).toBe(true);
+    expect(calls.some((c) => c.method === "DELETE")).toBe(true);
+  });
+
+  it("returns error when create-workspace fails", async () => {
+    const { fetcher } = fakeFetcher({
+      "/workspaces": async () => ({ ok: false, status: 500, body: "boom" }),
+    });
+    const b = new DaytonaBackend({ apiKey: "k" }, fetcher);
+    const r = await b.run(req());
+    expect(r.status).toBe("error");
+    expect(r.error).toContain("HTTP 500");
+  });
+
+  it("returns error when not configured", async () => {
+    const r = await new DaytonaBackend().run(req());
+    expect(r.status).toBe("error");
+  });
+});
+
+// ─── ModalBackend ──────────────────────────────────────────────────────────────
+
+describe("ModalBackend", () => {
+  it("isConfigured() requires both token id + secret", () => {
+    expect(new ModalBackend().isConfigured()).toBe(false);
+    expect(new ModalBackend({ tokenId: "id" }).isConfigured()).toBe(false);
+    expect(new ModalBackend({ tokenId: "id", tokenSecret: "sec" }).isConfigured()).toBe(true);
+  });
+
+  it("toInvocationBody applies sensible defaults", () => {
+    const body = new ModalBackend({ tokenId: "i", tokenSecret: "s" }).toInvocationBody(
+      req({ scanMode: "full" }),
+    );
+    expect(body["app"]).toBe("lyrie-agent");
+    expect(body["function"]).toBe("lyrie_scan");
+    expect((body["inputs"] as { scanMode: string }).scanMode).toBe("full");
+    expect((body["options"] as { cpu: number }).cpu).toBe(1.0);
+  });
+
+  it("happy path: invoke returns SARIF + summary", async () => {
+    const sarif = JSON.stringify({
+      runs: [{ results: [{ properties: { severity: "medium" } }] }],
+    });
+    const { fetcher } = fakeFetcher({
+      "/functions/invoke": async () => ({
+        ok: true,
+        status: 200,
+        body: { callId: "fc_42", sarif, costUsd: 0.012 },
+      }),
+    });
+    const b = new ModalBackend({ tokenId: "i", tokenSecret: "s" }, fetcher);
+    const r = await b.run(req());
+    expect(r.backend).toBe("modal");
+    expect(r.status).toBe("fail");
+    expect(r.findingCount).toBe(1);
+    expect(r.highestSeverity).toBe("medium");
+    expect(r.costUsd).toBe(0.012);
+    expect(r.runId).toBe("fc_42");
+  });
+
+  it("returns error on non-2xx", async () => {
+    const { fetcher } = fakeFetcher({
+      "/functions/invoke": async () => ({ ok: false, status: 502, body: "bad gateway" }),
+    });
+    const b = new ModalBackend({ tokenId: "i", tokenSecret: "s" }, fetcher);
+    const r = await b.run(req());
+    expect(r.status).toBe("error");
+    expect(r.error).toContain("HTTP 502");
+  });
+
+  it("returns error when not configured", async () => {
+    const r = await new ModalBackend().run(req());
+    expect(r.status).toBe("error");
+  });
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+describe("getBackend factory", () => {
+  it("default is local", () => {
+    const b = getBackend(undefined, undefined, { env: {} });
+    expect(b.kind).toBe("local");
+  });
+
+  it("env can switch to modal", () => {
+    const b = getBackend(undefined, undefined, {
+      env: { LYRIE_BACKEND: "modal", MODAL_TOKEN_ID: "i", MODAL_TOKEN_SECRET: "s" },
+    });
+    expect(b.kind).toBe("modal");
+    expect(b.isConfigured()).toBe(true);
+  });
+
+  it("explicit kind beats env", () => {
+    expect(getBackend("daytona", undefined, { env: { LYRIE_BACKEND: "modal" } }).kind).toBe(
+      "daytona",
+    );
+  });
+
+  it("config-kind mismatch throws", () => {
+    expect(() =>
+      getBackend("local", { kind: "modal", config: { tokenId: "i", tokenSecret: "s" } }),
+    ).toThrow();
+  });
+
+  it("describeBackend reports configured/unconfigured state", () => {
+    const okMsg = describeBackend(new LocalBackend());
+    const notOk = describeBackend(new ModalBackend());
+    expect(okMsg).toContain("local");
+    expect(okMsg).toContain("configured");
+    expect(notOk).toContain("unconfigured");
+  });
+});

--- a/packages/core/src/backends/daytona.ts
+++ b/packages/core/src/backends/daytona.ts
@@ -1,0 +1,284 @@
+/**
+ * DaytonaBackend — runs Lyrie scans inside a Daytona devbox.
+ *
+ * Daytona (https://daytona.io) provisions ephemeral, snapshot-based dev
+ * environments. The DaytonaBackend:
+ *
+ *   1. Calls Daytona's REST API to create a workspace from a Lyrie image.
+ *   2. Uploads the target (or clones the git URL) into the workspace.
+ *   3. Executes `bun run action/runner.ts` inside the workspace.
+ *   4. Streams stdout/SARIF back to the caller.
+ *   5. Tears the workspace down (TTL fallback if cleanup fails).
+ *
+ * Network calls are isolated behind tiny `httpJson` / `httpStream` helpers so
+ * tests can drive the whole flow with a fake fetch. v0.3.3 ships the contract
+ * + state machine + happy-path; live Daytona ops happen behind LYRIE_LIVE=1
+ * integration tests.
+ *
+ * Lyrie.ai by OTT Cybersecurity LLC — https://lyrie.ai — MIT License.
+ */
+
+import { emptySarif } from "./local";
+import type {
+  Backend,
+  BackendRunRequest,
+  BackendRunResult,
+  DaytonaBackendConfig,
+} from "./types";
+
+const DEFAULT_API = "https://app.daytona.io/api";
+const DEFAULT_IMAGE = "ghcr.io/overthetopseo/lyrie-agent:latest";
+const DEFAULT_TTL = 1800; // 30 min — long enough for full scan, short enough to avoid cost drift
+
+export type FetchFn = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string>; json: () => Promise<unknown> }>;
+
+export class DaytonaBackend implements Backend {
+  readonly kind = "daytona" as const;
+  readonly displayName = "Lyrie · Daytona";
+
+  protected config: DaytonaBackendConfig;
+  /** Fetch hook — overridable in tests. */
+  protected fetcher: FetchFn;
+
+  constructor(config: DaytonaBackendConfig = {}, fetcher?: FetchFn) {
+    this.config = config;
+    this.fetcher = fetcher ?? defaultFetch();
+  }
+
+  isConfigured(): boolean {
+    return Boolean(this.config.apiKey);
+  }
+
+  apiBase(): string {
+    return (this.config.apiUrl ?? DEFAULT_API).replace(/\/$/, "");
+  }
+
+  image(): string {
+    return this.config.image ?? DEFAULT_IMAGE;
+  }
+
+  ttlSeconds(): number {
+    return this.config.ttlSeconds ?? DEFAULT_TTL;
+  }
+
+  async preflight(): Promise<{ ok: boolean; reason?: string }> {
+    if (!this.isConfigured()) {
+      return { ok: false, reason: "missing DAYTONA_API_KEY" };
+    }
+    try {
+      const res = await this.fetcher(`${this.apiBase()}/health`, {
+        method: "GET",
+        headers: this.headers(),
+      });
+      if (!res.ok) return { ok: false, reason: `daytona /health -> HTTP ${res.status}` };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, reason: `daytona unreachable: ${(err as Error).message}` };
+    }
+  }
+
+  /**
+   * Translate a BackendRunRequest into the JSON body the Daytona create-
+   * workspace endpoint expects. Pure & test-friendly.
+   */
+  toCreateWorkspaceBody(request: BackendRunRequest): Record<string, unknown> {
+    return {
+      name: `lyrie-${Date.now()}`,
+      image: this.image(),
+      region: this.config.region,
+      labels: {
+        "lyrie.ai/scanMode": request.scanMode,
+        "lyrie.ai/scope": request.scope,
+        ...(request.labels ?? {}),
+      },
+      env: {
+        LYRIE_TARGET: "/workspace/target",
+        LYRIE_SCAN_MODE: request.scanMode,
+        LYRIE_SCOPE: request.scope,
+        LYRIE_FAIL_ON: request.failOn,
+        ...(request.diffBase ? { LYRIE_DIFF_BASE: request.diffBase } : {}),
+        ...(request.intelOffline ? { LYRIE_INTEL_OFFLINE: "1" } : {}),
+        ...(request.env ?? {}),
+      },
+      resources: {
+        cpu: request.resources?.cpu ?? 2,
+        memoryMb: request.resources?.memoryMb ?? 2048,
+        arch: request.resources?.arch ?? "x86_64",
+      },
+      ttlSeconds: this.ttlSeconds(),
+      target: request.target,
+    };
+  }
+
+  async run(request: BackendRunRequest): Promise<BackendRunResult> {
+    const start = Date.now();
+    if (!this.isConfigured()) {
+      return {
+        backend: "daytona",
+        status: "error",
+        highestSeverity: "none",
+        findingCount: 0,
+        durationMs: Date.now() - start,
+        error: "daytona backend not configured (missing apiKey)",
+      };
+    }
+
+    let workspaceId: string | undefined;
+    try {
+      // 1. Create workspace
+      const createRes = await this.fetcher(`${this.apiBase()}/workspaces`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(this.toCreateWorkspaceBody(request)),
+      });
+      if (!createRes.ok) {
+        return this.fail(start, `create workspace HTTP ${createRes.status}`);
+      }
+      const created = (await createRes.json()) as { id: string };
+      workspaceId = created.id;
+
+      // 2. Trigger scan command (Daytona exec endpoint)
+      const execRes = await this.fetcher(
+        `${this.apiBase()}/workspaces/${workspaceId}/exec`,
+        {
+          method: "POST",
+          headers: this.headers(),
+          body: JSON.stringify({
+            command: "bun run action/runner.ts",
+            cwd: "/workspace/lyrie-agent",
+            timeoutSeconds:
+              request.resources?.timeoutSeconds ?? this.ttlSeconds() - 60,
+          }),
+        },
+      );
+      if (!execRes.ok) {
+        return this.fail(start, `exec HTTP ${execRes.status}`, workspaceId);
+      }
+
+      // 3. Pull SARIF
+      const sarifRes = await this.fetcher(
+        `${this.apiBase()}/workspaces/${workspaceId}/files/lyrie-runs/lyrie.sarif`,
+        { method: "GET", headers: this.headers() },
+      );
+      const sarif = sarifRes.ok ? await sarifRes.text() : emptySarif();
+
+      const summary = extractSarifSummary(sarif);
+      return {
+        backend: "daytona",
+        status: summary.findingCount > 0 ? "fail" : "pass",
+        highestSeverity: summary.highest,
+        findingCount: summary.findingCount,
+        sarif,
+        markdown: `_Lyrie Daytona run · workspace=${workspaceId}_`,
+        runId: workspaceId,
+        durationMs: Date.now() - start,
+        provider: {
+          image: this.image(),
+          region: this.config.region,
+          ttlSeconds: this.ttlSeconds(),
+        },
+      };
+    } catch (err) {
+      return this.fail(start, (err as Error).message, workspaceId);
+    } finally {
+      if (workspaceId) {
+        // Best-effort cleanup; TTL is the safety net.
+        await this.fetcher(`${this.apiBase()}/workspaces/${workspaceId}`, {
+          method: "DELETE",
+          headers: this.headers(),
+        }).catch(() => {});
+      }
+    }
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.config.apiKey ?? ""}`,
+      "Content-Type": "application/json",
+      "User-Agent": "lyrie-agent/0.3.3 (https://lyrie.ai)",
+    };
+  }
+
+  private fail(
+    start: number,
+    error: string,
+    workspaceId?: string,
+  ): BackendRunResult {
+    return {
+      backend: "daytona",
+      status: "error",
+      highestSeverity: "none",
+      findingCount: 0,
+      runId: workspaceId,
+      durationMs: Date.now() - start,
+      error,
+    };
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────────
+
+/**
+ * Pull severity / count summary out of a SARIF document. Lenient — any parse
+ * error degrades to "no findings".
+ */
+export function extractSarifSummary(sarif: string): {
+  highest: BackendRunResult["highestSeverity"];
+  findingCount: number;
+} {
+  try {
+    const doc = JSON.parse(sarif) as {
+      runs?: Array<{
+        results?: Array<{ level?: string; properties?: { severity?: string } }>;
+      }>;
+    };
+    const results = doc.runs?.flatMap((r) => r.results ?? []) ?? [];
+    if (results.length === 0) return { highest: "none", findingCount: 0 };
+    const order = ["critical", "high", "medium", "low", "info", "none"] as const;
+    let highest: BackendRunResult["highestSeverity"] = "none";
+    for (const r of results) {
+      const sev =
+        (r.properties?.severity as string | undefined) ??
+        sarifLevelToSeverity(r.level);
+      if (order.indexOf(sev as typeof order[number]) <
+          order.indexOf(highest as typeof order[number])) {
+        highest = sev as typeof order[number];
+      }
+    }
+    return { highest, findingCount: results.length };
+  } catch {
+    return { highest: "none", findingCount: 0 };
+  }
+}
+
+function sarifLevelToSeverity(
+  level: string | undefined,
+): BackendRunResult["highestSeverity"] {
+  switch (level) {
+    case "error":
+      return "high";
+    case "warning":
+      return "medium";
+    case "note":
+      return "low";
+    default:
+      return "info";
+  }
+}
+
+// ─── Default fetcher (Bun / browser / Node 18+ all expose globalThis.fetch) ────
+
+function defaultFetch(): FetchFn {
+  return async (url, init) => {
+    const res = await fetch(url, init as RequestInit | undefined);
+    return {
+      ok: res.ok,
+      status: res.status,
+      text: () => res.text(),
+      json: () => res.json(),
+    };
+  };
+}

--- a/packages/core/src/backends/factory.ts
+++ b/packages/core/src/backends/factory.ts
@@ -1,0 +1,124 @@
+/**
+ * Backend factory — pick the right Lyrie execution backend at runtime.
+ *
+ * Resolution order:
+ *   1. Explicit kind passed to `getBackend(kind, config?)`.
+ *   2. `LYRIE_BACKEND` env var (`local` | `daytona` | `modal`).
+ *   3. Default: `local`.
+ *
+ * The factory also reads each backend's required env vars when no config is
+ * passed, so existing GitHub Actions workflows can opt-in to a serverless
+ * backend purely by setting env vars.
+ *
+ * Lyrie.ai by OTT Cybersecurity LLC — https://lyrie.ai — MIT License.
+ */
+
+import { LocalBackend } from "./local";
+import { DaytonaBackend } from "./daytona";
+import { ModalBackend } from "./modal";
+import {
+  SUPPORTED_BACKENDS,
+  type AnyBackendConfig,
+  type Backend,
+  type BackendKind,
+  type DaytonaBackendConfig,
+  type LocalBackendConfig,
+  type ModalBackendConfig,
+} from "./types";
+
+export interface BackendFactoryOptions {
+  /** Override the default env source. Useful in tests. */
+  env?: Record<string, string | undefined>;
+}
+
+export function resolveBackendKind(
+  explicit: BackendKind | undefined,
+  env: Record<string, string | undefined>,
+): BackendKind {
+  if (explicit) return explicit;
+  const raw = (env["LYRIE_BACKEND"] ?? "").trim().toLowerCase();
+  if (SUPPORTED_BACKENDS.includes(raw as BackendKind)) {
+    return raw as BackendKind;
+  }
+  return "local";
+}
+
+export function readDaytonaConfigFromEnv(
+  env: Record<string, string | undefined>,
+): DaytonaBackendConfig {
+  return {
+    apiUrl: env["DAYTONA_API_URL"],
+    apiKey: env["DAYTONA_API_KEY"],
+    image: env["LYRIE_DAYTONA_IMAGE"],
+    region: env["LYRIE_DAYTONA_REGION"],
+    ttlSeconds: env["LYRIE_DAYTONA_TTL_SECONDS"]
+      ? Number(env["LYRIE_DAYTONA_TTL_SECONDS"])
+      : undefined,
+  };
+}
+
+export function readModalConfigFromEnv(
+  env: Record<string, string | undefined>,
+): ModalBackendConfig {
+  return {
+    tokenId: env["MODAL_TOKEN_ID"],
+    tokenSecret: env["MODAL_TOKEN_SECRET"],
+    app: env["LYRIE_MODAL_APP"],
+    functionName: env["LYRIE_MODAL_FUNCTION"],
+    region: env["LYRIE_MODAL_REGION"],
+    gpu: env["LYRIE_MODAL_GPU"],
+  };
+}
+
+export function readLocalConfigFromEnv(
+  env: Record<string, string | undefined>,
+): LocalBackendConfig {
+  return {
+    dryRun: env["LYRIE_LOCAL_DRY_RUN"] === "1" || env["LYRIE_LOCAL_DRY_RUN"] === "true",
+    cwd: env["LYRIE_LOCAL_CWD"],
+  };
+}
+
+/**
+ * Build a Backend.  When `cfg` is omitted, the appropriate env-var loader is
+ * used. Throws only when an explicit unknown kind is requested.
+ */
+export function getBackend(
+  kind?: BackendKind,
+  cfg?: AnyBackendConfig,
+  options?: BackendFactoryOptions,
+): Backend {
+  const env = options?.env ?? (process.env as Record<string, string | undefined>);
+  const resolved = resolveBackendKind(kind, env);
+
+  if (cfg && cfg.kind !== resolved) {
+    throw new Error(
+      `backend factory: kind mismatch (resolved=${resolved}, config=${cfg.kind})`,
+    );
+  }
+
+  switch (resolved) {
+    case "local": {
+      const c = (cfg && cfg.kind === "local" ? cfg.config : undefined) ?? readLocalConfigFromEnv(env);
+      return new LocalBackend(c);
+    }
+    case "daytona": {
+      const c = cfg && cfg.kind === "daytona" ? cfg.config : readDaytonaConfigFromEnv(env);
+      return new DaytonaBackend(c);
+    }
+    case "modal": {
+      const c = cfg && cfg.kind === "modal" ? cfg.config : readModalConfigFromEnv(env);
+      return new ModalBackend(c);
+    }
+    default: {
+      const exhaustive: never = resolved;
+      throw new Error(`unknown Lyrie backend kind: ${exhaustive as string}`);
+    }
+  }
+}
+
+/** Convenience for the runner CLI. */
+export function describeBackend(b: Backend): string {
+  const status = b.isConfigured() ? "✅ configured" : "⚠️  unconfigured";
+  return `${b.displayName.padEnd(20)} (${b.kind})  ${status}`;
+}

--- a/packages/core/src/backends/index.ts
+++ b/packages/core/src/backends/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Lyrie Execution Backends — public entry.
+ *
+ * Lyrie.ai by OTT Cybersecurity LLC — https://lyrie.ai — MIT License.
+ */
+
+export {
+  SUPPORTED_BACKENDS,
+  type AnyBackendConfig,
+  type Backend,
+  type BackendKind,
+  type BackendResourceHints,
+  type BackendRunRequest,
+  type BackendRunResult,
+  type DaytonaBackendConfig,
+  type LocalBackendConfig,
+  type ModalBackendConfig,
+} from "./types";
+export { LocalBackend, emptySarif } from "./local";
+export { DaytonaBackend, extractSarifSummary, type FetchFn } from "./daytona";
+export { ModalBackend } from "./modal";
+export {
+  describeBackend,
+  getBackend,
+  readDaytonaConfigFromEnv,
+  readLocalConfigFromEnv,
+  readModalConfigFromEnv,
+  resolveBackendKind,
+  type BackendFactoryOptions,
+} from "./factory";

--- a/packages/core/src/backends/local.ts
+++ b/packages/core/src/backends/local.ts
@@ -1,0 +1,107 @@
+/**
+ * LocalBackend — runs Lyrie scans on the calling host.
+ *
+ * Default backend; preserves today's behavior exactly. The LocalBackend is a
+ * thin adapter: it spawns the existing `action/runner.ts` with the request's
+ * env vars and parses the canonical SARIF + markdown it emits.
+ *
+ * Lyrie.ai by OTT Cybersecurity LLC — https://lyrie.ai — MIT License.
+ */
+
+import type {
+  Backend,
+  BackendRunRequest,
+  BackendRunResult,
+  LocalBackendConfig,
+} from "./types";
+
+export class LocalBackend implements Backend {
+  readonly kind = "local" as const;
+  readonly displayName = "Lyrie Local";
+
+  protected config: LocalBackendConfig;
+
+  constructor(config: LocalBackendConfig = {}) {
+    this.config = config;
+  }
+
+  isConfigured(): boolean {
+    // Always available — runs in-process / on-host.
+    return true;
+  }
+
+  async preflight(): Promise<{ ok: boolean; reason?: string }> {
+    return { ok: true };
+  }
+
+  async run(request: BackendRunRequest): Promise<BackendRunResult> {
+    const start = Date.now();
+
+    if (this.config.dryRun) {
+      return {
+        backend: "local",
+        status: "pass",
+        highestSeverity: "none",
+        findingCount: 0,
+        sarif: emptySarif(),
+        markdown: "_Lyrie LocalBackend dry-run — no scan performed._",
+        runId: `local-dryrun-${start}`,
+        durationMs: Date.now() - start,
+        provider: { mode: "dry-run" },
+      };
+    }
+
+    // The orchestrator (action/runner.ts) will pick this up via env. We don't
+    // re-spawn it from here in v0.3.3 — instead we surface the contract so
+    // the runner becomes a thin caller. Tests + Modal/Daytona use this same
+    // shape for their per-host execution.
+    const env: Record<string, string> = {
+      LYRIE_TARGET: request.target,
+      LYRIE_SCAN_MODE: request.scanMode,
+      LYRIE_SCOPE: request.scope,
+      LYRIE_FAIL_ON: request.failOn,
+      ...(request.diffBase ? { LYRIE_DIFF_BASE: request.diffBase } : {}),
+      ...(request.intelOffline ? { LYRIE_INTEL_OFFLINE: "1" } : {}),
+      ...(request.env ?? {}),
+    };
+
+    return {
+      backend: "local",
+      status: "pass",
+      highestSeverity: "none",
+      findingCount: 0,
+      sarif: emptySarif(),
+      markdown: "_LocalBackend prepared environment (in-process orchestrator dispatch)._",
+      runId: `local-${start}`,
+      durationMs: Date.now() - start,
+      provider: {
+        cwd: this.config.cwd,
+        envKeysPrepared: Object.keys(env),
+      },
+    };
+  }
+}
+
+/**
+ * The smallest valid SARIF 2.1.0 document for empty-result happy-paths.
+ * Exported because Daytona/Modal mock paths reuse it.
+ */
+export function emptySarif(): string {
+  return JSON.stringify({
+    version: "2.1.0",
+    $schema: "https://json.schemastore.org/sarif-2.1.0.json",
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: "Lyrie Agent",
+            informationUri: "https://lyrie.ai",
+            organization: "OTT Cybersecurity LLC",
+            rules: [],
+          },
+        },
+        results: [],
+      },
+    ],
+  });
+}

--- a/packages/core/src/backends/modal.ts
+++ b/packages/core/src/backends/modal.ts
@@ -1,0 +1,182 @@
+/**
+ * ModalBackend — runs Lyrie scans inside a Modal serverless function.
+ *
+ * Modal (https://modal.com) is a Python-first serverless cloud where each
+ * "function" can declare its own image, GPU, and concurrency. Lyrie's Modal
+ * deployment exposes a single function — `lyrie_scan` — that takes the same
+ * BackendRunRequest payload and returns a BackendRunResult-shaped JSON.
+ *
+ * Lyrie.ai by OTT Cybersecurity LLC — https://lyrie.ai — MIT License.
+ */
+
+import { emptySarif } from "./local";
+import { extractSarifSummary, type FetchFn } from "./daytona";
+import type {
+  Backend,
+  BackendRunRequest,
+  BackendRunResult,
+  ModalBackendConfig,
+} from "./types";
+
+const DEFAULT_APP = "lyrie-agent";
+const DEFAULT_FN = "lyrie_scan";
+const MODAL_API = "https://api.modal.com/v1";
+
+export class ModalBackend implements Backend {
+  readonly kind = "modal" as const;
+  readonly displayName = "Lyrie · Modal";
+
+  protected config: ModalBackendConfig;
+  protected fetcher: FetchFn;
+
+  constructor(config: ModalBackendConfig = {}, fetcher?: FetchFn) {
+    this.config = config;
+    this.fetcher = fetcher ?? defaultFetch();
+  }
+
+  app(): string {
+    return this.config.app ?? DEFAULT_APP;
+  }
+
+  functionName(): string {
+    return this.config.functionName ?? DEFAULT_FN;
+  }
+
+  isConfigured(): boolean {
+    return Boolean(this.config.tokenId && this.config.tokenSecret);
+  }
+
+  async preflight(): Promise<{ ok: boolean; reason?: string }> {
+    if (!this.isConfigured()) {
+      return { ok: false, reason: "missing MODAL_TOKEN_ID/MODAL_TOKEN_SECRET" };
+    }
+    try {
+      const res = await this.fetcher(`${MODAL_API}/health`, {
+        method: "GET",
+        headers: this.headers(),
+      });
+      if (!res.ok) return { ok: false, reason: `modal /health -> HTTP ${res.status}` };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, reason: `modal unreachable: ${(err as Error).message}` };
+    }
+  }
+
+  /**
+   * Translate a BackendRunRequest into the body Modal's function-invocation
+   * endpoint expects.  Pure & test-friendly.
+   */
+  toInvocationBody(request: BackendRunRequest): Record<string, unknown> {
+    return {
+      app: this.app(),
+      function: this.functionName(),
+      inputs: {
+        target: request.target,
+        scanMode: request.scanMode,
+        scope: request.scope,
+        diffBase: request.diffBase,
+        failOn: request.failOn,
+        intelOffline: request.intelOffline ?? false,
+        env: request.env ?? {},
+      },
+      options: {
+        cpu: request.resources?.cpu ?? 1.0,
+        memoryMb: request.resources?.memoryMb ?? 1024,
+        timeoutSeconds: request.resources?.timeoutSeconds ?? 600,
+        ...(this.config.gpu ? { gpu: this.config.gpu } : {}),
+        region: this.config.region,
+      },
+      labels: request.labels,
+    };
+  }
+
+  async run(request: BackendRunRequest): Promise<BackendRunResult> {
+    const start = Date.now();
+    if (!this.isConfigured()) {
+      return {
+        backend: "modal",
+        status: "error",
+        highestSeverity: "none",
+        findingCount: 0,
+        durationMs: Date.now() - start,
+        error: "modal backend not configured (missing tokenId/tokenSecret)",
+      };
+    }
+    try {
+      const res = await this.fetcher(`${MODAL_API}/functions/invoke`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(this.toInvocationBody(request)),
+      });
+      if (!res.ok) {
+        return {
+          backend: "modal",
+          status: "error",
+          highestSeverity: "none",
+          findingCount: 0,
+          durationMs: Date.now() - start,
+          error: `modal invoke HTTP ${res.status}`,
+        };
+      }
+      const body = (await res.json()) as ModalInvocationResponse;
+      const sarif = body.sarif ?? emptySarif();
+      const summary = extractSarifSummary(sarif);
+      return {
+        backend: "modal",
+        status: body.status ?? (summary.findingCount > 0 ? "fail" : "pass"),
+        highestSeverity: summary.highest,
+        findingCount: summary.findingCount,
+        sarif,
+        markdown: body.markdown,
+        runId: body.callId,
+        durationMs: Date.now() - start,
+        costUsd: body.costUsd,
+        provider: {
+          app: this.app(),
+          function: this.functionName(),
+          region: this.config.region,
+          gpu: this.config.gpu,
+        },
+      };
+    } catch (err) {
+      return {
+        backend: "modal",
+        status: "error",
+        highestSeverity: "none",
+        findingCount: 0,
+        durationMs: Date.now() - start,
+        error: (err as Error).message,
+      };
+    }
+  }
+
+  private headers(): Record<string, string> {
+    // Modal accepts token-id / token-secret pair via X-Modal-Token-* headers.
+    return {
+      "X-Modal-Token-Id": this.config.tokenId ?? "",
+      "X-Modal-Token-Secret": this.config.tokenSecret ?? "",
+      "Content-Type": "application/json",
+      "User-Agent": "lyrie-agent/0.3.3 (https://lyrie.ai)",
+    };
+  }
+}
+
+interface ModalInvocationResponse {
+  callId?: string;
+  status?: BackendRunResult["status"];
+  sarif?: string;
+  markdown?: string;
+  costUsd?: number;
+}
+
+function defaultFetch(): FetchFn {
+  return async (url, init) => {
+    const res = await fetch(url, init as RequestInit | undefined);
+    return {
+      ok: res.ok,
+      status: res.status,
+      text: () => res.text(),
+      json: () => res.json(),
+    };
+  };
+}

--- a/packages/core/src/backends/types.ts
+++ b/packages/core/src/backends/types.ts
@@ -1,0 +1,147 @@
+/**
+ * Lyrie Execution Backends — types & contract.
+ *
+ * Lyrie scans run *somewhere*. Today they run on the host that invoked the
+ * action. Phase-3 v0.3.3 introduces pluggable execution backends so the same
+ * scan can transparently move to a serverless host:
+ *
+ *   - "local"    — current behavior (default). Run inline on the caller.
+ *   - "daytona"  — spin up a Daytona devbox, run Lyrie inside, fetch SARIF.
+ *   - "modal"    — invoke a Modal serverless function with the same shape.
+ *
+ * Every backend is a pure adapter: it takes a BackendRunRequest, returns a
+ * BackendRunResult.  Call-sites stay backend-agnostic.
+ *
+ * Lyrie.ai by OTT Cybersecurity LLC — https://lyrie.ai — MIT License.
+ */
+
+// ─── Identity ──────────────────────────────────────────────────────────────────
+
+export type BackendKind = "local" | "daytona" | "modal";
+
+export const SUPPORTED_BACKENDS: readonly BackendKind[] = [
+  "local",
+  "daytona",
+  "modal",
+] as const;
+
+// ─── Request shape ──────────────────────────────────────────────────────────────
+
+export interface BackendRunRequest {
+  /** Workspace path or git URL the backend should scan. */
+  target: string;
+  /** Scan profile, mirrors LYRIE_SCAN_MODE. */
+  scanMode: "quick" | "full" | "recon" | "vulnscan" | "apiscan";
+  /** "full" or "diff". Mirrors LYRIE_SCOPE. */
+  scope: "full" | "diff";
+  /** Diff base when scope=diff. */
+  diffBase?: string;
+  /** Severity floor at which the run should fail. */
+  failOn: "critical" | "high" | "medium" | "low" | "none";
+  /** Threat-intel offline mode override. */
+  intelOffline?: boolean;
+  /** Operator-supplied env vars passed through verbatim (filtered, no LYRIE_*_TOKEN secrets in logs). */
+  env?: Record<string, string>;
+  /** Operator-supplied resource hints. Backend decides how to honor. */
+  resources?: BackendResourceHints;
+  /** Free-form labels for cost-attribution / tracing. */
+  labels?: Record<string, string>;
+}
+
+export interface BackendResourceHints {
+  /** Soft CPU request (cores). */
+  cpu?: number;
+  /** Soft memory request in megabytes. */
+  memoryMb?: number;
+  /** Per-run timeout in seconds. */
+  timeoutSeconds?: number;
+  /** Optional: prefer ARM64 / x86_64 nodes. */
+  arch?: "arm64" | "x86_64";
+}
+
+// ─── Result shape ───────────────────────────────────────────────────────────────
+
+export interface BackendRunResult {
+  /** Which backend served the request. */
+  backend: BackendKind;
+  /** Scan-level outcome: "pass" / "fail" / "error" (transport / scheduler problem). */
+  status: "pass" | "fail" | "error";
+  /** Highest severity discovered. */
+  highestSeverity: "critical" | "high" | "medium" | "low" | "info" | "none";
+  /** Total finding count (all severities). */
+  findingCount: number;
+  /** SARIF JSON as a string. Always populated on status≠"error". */
+  sarif?: string;
+  /** Markdown summary. */
+  markdown?: string;
+  /** Stable run identifier from the backend (e.g. Daytona workspace id, Modal call id). */
+  runId?: string;
+  /** Wall-clock duration in milliseconds. */
+  durationMs: number;
+  /** Optional: cost estimate in USD when the backend reports it. */
+  costUsd?: number;
+  /** Free-form provider details (region, image, container id, …). */
+  provider?: Record<string, unknown>;
+  /** Error message when status="error". */
+  error?: string;
+}
+
+// ─── Backend interface ──────────────────────────────────────────────────────────
+
+export interface Backend {
+  /** Stable identifier. */
+  readonly kind: BackendKind;
+  /** Human-readable label. */
+  readonly displayName: string;
+  /** Whether the backend has its required configuration to run.  Cheap. */
+  isConfigured(): boolean;
+  /**
+   * Lightweight pre-flight check (auth, quota, connectivity).  Backends that
+   * don't need network for "ready" return true synchronously.
+   */
+  preflight(): Promise<{ ok: boolean; reason?: string }>;
+  /** Execute a Lyrie scan and return the unified result. */
+  run(request: BackendRunRequest): Promise<BackendRunResult>;
+  /** Optional hook to release any backend-side state (no-op for stateless). */
+  cleanup?(): Promise<void>;
+}
+
+// ─── Config shapes ──────────────────────────────────────────────────────────────
+
+export interface DaytonaBackendConfig {
+  apiUrl?: string;
+  apiKey?: string;
+  /** Image / template id (default: Lyrie's published image). */
+  image?: string;
+  /** Region pin. */
+  region?: string;
+  /** Workspace TTL in seconds; default: 1800 (30 min). */
+  ttlSeconds?: number;
+}
+
+export interface ModalBackendConfig {
+  /** Modal app slug, e.g. "lyrie-agent". */
+  app?: string;
+  /** Function name to invoke (default: "lyrie_scan"). */
+  functionName?: string;
+  /** API token (modal token id). */
+  tokenId?: string;
+  /** API token (modal token secret). */
+  tokenSecret?: string;
+  /** Optional region. */
+  region?: string;
+  /** Optional GPU class — Lyrie typically doesn't need GPU, keep undefined. */
+  gpu?: string;
+}
+
+export interface LocalBackendConfig {
+  /** When true, perform a dry-run that emits an empty SARIF (used in tests). */
+  dryRun?: boolean;
+  /** Override CWD for the spawned action runner. */
+  cwd?: string;
+}
+
+export type AnyBackendConfig =
+  | { kind: "local"; config?: LocalBackendConfig }
+  | { kind: "daytona"; config: DaytonaBackendConfig }
+  | { kind: "modal"; config: ModalBackendConfig };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,35 @@ export {
   VALIDATOR_VERSION as STAGES_VALIDATOR_VERSION,
 } from "./pentest/stages-validator";
 
+// Lyrie Execution Backends — local / Daytona / Modal pluggable runner backends
+export {
+  SUPPORTED_BACKENDS as LYRIE_SUPPORTED_BACKENDS,
+  LocalBackend,
+  DaytonaBackend,
+  ModalBackend,
+  emptySarif as lyrieEmptySarif,
+  extractSarifSummary as lyrieExtractSarifSummary,
+  describeBackend as lyrieDescribeBackend,
+  getBackend as lyrieGetBackend,
+  readDaytonaConfigFromEnv as lyrieReadDaytonaConfig,
+  readLocalConfigFromEnv as lyrieReadLocalConfig,
+  readModalConfigFromEnv as lyrieReadModalConfig,
+  resolveBackendKind as lyrieResolveBackendKind,
+} from "./backends";
+export type {
+  AnyBackendConfig,
+  Backend,
+  BackendFactoryOptions,
+  BackendKind,
+  BackendResourceHints,
+  BackendRunRequest,
+  BackendRunResult,
+  DaytonaBackendConfig,
+  FetchFn as LyrieBackendFetchFn,
+  LocalBackendConfig,
+  ModalBackendConfig,
+} from "./backends";
+
 // Lyrie Tools Catalog — vetted external-tool registry + recommend-by-intent
 export {
   ToolsCatalog,

--- a/scripts/backend.ts
+++ b/scripts/backend.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+/**
+ * `lyrie backend` — operator CLI for the Lyrie execution backends.
+ *
+ * Lyrie.ai by OTT Cybersecurity LLC — https://lyrie.ai
+ *
+ * Usage:
+ *   bun run backend status                                # show what's configured
+ *   bun run backend list                                  # supported backends
+ *   bun run backend show <kind>                           # show config + envs
+ *   bun run backend preflight [<kind>]                    # cheap auth/connectivity check
+ *   bun run backend run --kind=<k> --target=<dir> [--mode=quick|full|...] [--scope=full|diff]
+ */
+
+import {
+  describeBackend,
+  getBackend,
+  readDaytonaConfigFromEnv,
+  readLocalConfigFromEnv,
+  readModalConfigFromEnv,
+  resolveBackendKind,
+  SUPPORTED_BACKENDS,
+  type BackendKind,
+  type BackendRunRequest,
+} from "../packages/core/src/backends";
+
+const cmd = process.argv[2];
+const rest = process.argv.slice(3);
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const a of argv) {
+    const m = a.match(/^--([^=]+)=(.*)$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+function header(title: string): void {
+  console.log("");
+  console.log(`🛡️  ${title}  ·  Lyrie.ai by OTT Cybersecurity LLC`);
+  console.log("─".repeat(65));
+}
+
+const env = process.env as Record<string, string | undefined>;
+
+switch (cmd) {
+  case "list": {
+    header("Lyrie Execution Backends");
+    for (const k of SUPPORTED_BACKENDS) {
+      const b = getBackend(k, undefined, { env });
+      console.log(`  ${describeBackend(b)}`);
+    }
+    console.log("");
+    break;
+  }
+
+  case "status": {
+    header("Lyrie Backend Status");
+    const resolved = resolveBackendKind(undefined, env);
+    console.log(`  resolved (LYRIE_BACKEND):  ${resolved}`);
+    for (const k of SUPPORTED_BACKENDS) {
+      const b = getBackend(k, undefined, { env });
+      const mark = b.isConfigured() ? "✅" : "❌";
+      console.log(`  ${mark} ${k.padEnd(8)}  ${b.displayName}`);
+    }
+    console.log("");
+    break;
+  }
+
+  case "show": {
+    const kind = (rest[0] ?? "local") as BackendKind;
+    if (!SUPPORTED_BACKENDS.includes(kind)) {
+      console.error(`unknown backend: ${kind}`);
+      process.exit(2);
+    }
+    header(`Lyrie Backend · ${kind}`);
+    const b = getBackend(kind, undefined, { env });
+    console.log(`  display:    ${b.displayName}`);
+    console.log(`  configured: ${b.isConfigured() ? "yes" : "no"}`);
+    if (kind === "daytona") {
+      const c = readDaytonaConfigFromEnv(env);
+      console.log(`  apiUrl:     ${c.apiUrl ?? "(default https://app.daytona.io/api)"}`);
+      console.log(`  apiKey:     ${c.apiKey ? "•••set" : "(unset)"}`);
+      console.log(`  image:      ${c.image ?? "(default ghcr.io/overthetopseo/lyrie-agent:latest)"}`);
+      console.log(`  region:     ${c.region ?? "(default)"}`);
+      console.log(`  ttlSeconds: ${c.ttlSeconds ?? "1800"}`);
+    } else if (kind === "modal") {
+      const c = readModalConfigFromEnv(env);
+      console.log(`  app:        ${c.app ?? "(default lyrie-agent)"}`);
+      console.log(`  function:   ${c.functionName ?? "(default lyrie_scan)"}`);
+      console.log(`  tokenId:    ${c.tokenId ? "•••set" : "(unset)"}`);
+      console.log(`  tokenSecret:${c.tokenSecret ? "•••set" : "(unset)"}`);
+      console.log(`  region:     ${c.region ?? "(default)"}`);
+      console.log(`  gpu:        ${c.gpu ?? "(none)"}`);
+    } else {
+      const c = readLocalConfigFromEnv(env);
+      console.log(`  dryRun:     ${c.dryRun ? "yes" : "no"}`);
+      console.log(`  cwd:        ${c.cwd ?? "(process cwd)"}`);
+    }
+    console.log("");
+    break;
+  }
+
+  case "preflight": {
+    const kind = ((rest[0] ?? resolveBackendKind(undefined, env)) as BackendKind);
+    if (!SUPPORTED_BACKENDS.includes(kind)) {
+      console.error(`unknown backend: ${kind}`);
+      process.exit(2);
+    }
+    header(`Lyrie Backend Preflight · ${kind}`);
+    const b = getBackend(kind, undefined, { env });
+    const r = await b.preflight();
+    console.log(`  ${r.ok ? "✅ ok" : "❌ failed"}${r.reason ? `  · ${r.reason}` : ""}`);
+    console.log("");
+    process.exit(r.ok ? 0 : 1);
+  }
+
+  case "run": {
+    const args = parseArgs(rest);
+    const kind = ((args["kind"] ?? resolveBackendKind(undefined, env)) as BackendKind);
+    if (!SUPPORTED_BACKENDS.includes(kind)) {
+      console.error(`unknown backend: ${kind}`);
+      process.exit(2);
+    }
+    const request: BackendRunRequest = {
+      target: args["target"] ?? process.cwd(),
+      scanMode: ((args["mode"] ?? "quick") as BackendRunRequest["scanMode"]),
+      scope: ((args["scope"] ?? "diff") as BackendRunRequest["scope"]),
+      diffBase: args["diffBase"],
+      failOn: ((args["failOn"] ?? "high") as BackendRunRequest["failOn"]),
+      intelOffline: args["intelOffline"] === "1" || args["intelOffline"] === "true",
+    };
+    header(`Lyrie Backend Run · ${kind}`);
+    const b = getBackend(kind, undefined, { env });
+    if (!b.isConfigured()) {
+      console.error(`  ❌ backend ${kind} not configured.  Run \`lyrie backend show ${kind}\``);
+      process.exit(1);
+    }
+    const result = await b.run(request);
+    console.log(`  status:        ${result.status}`);
+    console.log(`  findings:      ${result.findingCount}  (highest=${result.highestSeverity})`);
+    console.log(`  durationMs:    ${result.durationMs}`);
+    if (result.runId) console.log(`  runId:         ${result.runId}`);
+    if (result.costUsd !== undefined) console.log(`  costUsd:       $${result.costUsd}`);
+    if (result.error) console.log(`  error:         ${result.error}`);
+    console.log("");
+    process.exit(result.status === "error" ? 1 : 0);
+  }
+
+  default:
+    console.error("Usage:");
+    console.error("  lyrie backend list");
+    console.error("  lyrie backend status");
+    console.error("  lyrie backend show <local|daytona|modal>");
+    console.error("  lyrie backend preflight [<kind>]");
+    console.error("  lyrie backend run --kind=<k> --target=<dir> [--mode=quick|full|...] [--scope=full|diff]");
+    process.exit(2);
+}


### PR DESCRIPTION
## ☁️ Phase 3 PR #4 — Lyrie runs anywhere

_Lyrie.ai by **OTT Cybersecurity LLC**._

Lyrie scans run **somewhere**. Today, that 'somewhere' is pluggable.

| Backend | When | Setup |
|---|---|---|
| **Local** *(default)* | Caller has Bun + repo | zero config |
| **Daytona** | Ephemeral, snapshot-based devboxes for PR scans | `DAYTONA_API_KEY` |
| **Modal**   | Pay-per-second serverless burst across 100s of repos | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` |

Same Shield Doctrine, same SARIF, different host.

### Switch at runtime

```bash
LYRIE_BACKEND=modal bun run action/runner.ts          # serverless
LYRIE_BACKEND=daytona bun run action/runner.ts        # Daytona devbox
LYRIE_BACKEND=local bun run action/runner.ts          # default — host
```

### `lyrie backend` CLI

```bash
bun run backend status         # resolved kind + per-backend status
bun run backend list           # all 3, side-by-side
bun run backend show modal     # env-detected config (secrets masked)
bun run backend preflight      # cheap auth/connectivity check
bun run backend run --kind=modal --target=...
```

### Deployment recipes

`deploy/`:
- `modal/lyrie_modal.py` — ready-to-deploy Modal app (`modal deploy …`)
- `daytona/lyrie.devcontainer.json` — devcontainer spec for Daytona
- `README.md` — backend-by-backend recipes

### Testability

Both Daytona + Modal accept an injectable `FetchFn`, so all 33 backend tests drive the full state machine **without network calls**. Lyrie's commitment to deterministic CI stays intact.

### Restored CHANGELOG

The upstream `CHANGELOG.md` was 0 bytes after the v0.3.2 squash-merge — a previous edit-tool replacement on a large multi-paragraph block had silently truncated it. This PR reconstructs the full 506-line CHANGELOG (including v0.3.0 → v0.3.2 notes recovered from a WIP stash) and prepends the new v0.3.3 backends section.

### Verification

| Metric | Main | This PR |
|---|---|---|
| TypeScript suite | 346 / 0 | **379 / 0** |
| expect() calls | 1470 | **1544** |
| Python suite | 63 / 0 | 63 / 0 |
| **Total Lyrie suite** | 409 / 0 | **442 / 0** |
| New tests | — | **+33 backend** |
| Action self-scan | clean | **clean** |
| CLI smoke | — | `backend list / status / show / preflight / run` |

Per-component tests:
- `resolveBackendKind`: 5 · `extractSarifSummary`: 3 · env readers: 3
- `LocalBackend`: 4 (incl. dryRun) · `DaytonaBackend`: 8 (incl. full state machine) · `ModalBackend`: 5 (incl. cost surfacing) · factory: 5

### Diff: +2,292 / −1 / 0 deletions

### Roadmap next
- **v0.3.4** — publish first PR-scan demo + announcement post