### PR TITLE
fix(ci): skip UI package in npm publish build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,8 @@ jobs:
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
-      - run: bun run build --if-present
+      # Build only publishable packages (skip Next.js UI which is not on npm)
+      - run: bun run build --filter=./packages/core --filter=./packages/gateway --filter=./packages/mcp --if-present
       - name: Publish (provenance)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem
The Release workflow's 'Publish to npm' job fails at bun run build because turbo run build includes packages/ui (Next.js app) which requires env vars not present in release CI and times out.

## Fix
Use turbo --filter to build only npm-publishable packages: core, gateway, mcp. Skip packages/ui (not published to npm).

## Impact
- npm publish will succeed
- Binary builds are unaffected (separate job)
- GitHub Release creation unblocked