### PR TITLE
feat(sarif-viewer): SARIF 2.1.0 viewer — types, parser, DOM renderer, tests & demo

### DIFF
--- a/packages/ui/src/app/sarif-demo/SarifDemoClient.tsx
+++ b/packages/ui/src/app/sarif-demo/SarifDemoClient.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { SarifViewer } from "@/sarif-viewer";
+
+// ---------------------------------------------------------------------------
+// Sample SARIF — realistic lyrie scan output
+// ---------------------------------------------------------------------------
+const SAMPLE_SARIF = JSON.stringify(
+  {
+    version: "2.1.0",
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: "Lyrie",
+            version: "0.1.0",
+            rules: [
+              {
+                id: "SQL001",
+                name: "SqlInjection",
+                shortDescription: { text: "Unsanitised user input in SQL query" },
+                defaultConfiguration: { level: "error" },
+                helpUri: "https://lyrie.ai/rules/SQL001",
+              },
+              {
+                id: "XSS002",
+                name: "CrossSiteScripting",
+                shortDescription: { text: "Reflected XSS via unescaped template variable" },
+                defaultConfiguration: { level: "warning" },
+                helpUri: "https://lyrie.ai/rules/XSS002",
+              },
+              {
+                id: "CSRF003",
+                name: "CrossSiteRequestForgery",
+                shortDescription: { text: "Endpoint missing CSRF token validation" },
+                defaultConfiguration: { level: "warning" },
+                helpUri: "https://lyrie.ai/rules/CSRF003",
+              },
+              {
+                id: "INFO001",
+                name: "SensitiveDataExposure",
+                shortDescription: { text: "Stack trace or secret leaked in HTTP response" },
+                defaultConfiguration: { level: "note" },
+                helpUri: "https://lyrie.ai/rules/INFO001",
+              },
+            ],
+          },
+        },
+        results: [
+          {
+            ruleId: "SQL001",
+            level: "error",
+            message: { text: "Raw user input concatenated into SQL query without parameterisation." },
+            locations: [
+              {
+                physicalLocation: {
+                  artifactLocation: { uri: "src/auth/login.ts" },
+                  region: { startLine: 42, startColumn: 12 },
+                },
+              },
+            ],
+          },
+          {
+            ruleId: "SQL001",
+            level: "error",
+            message: { text: "Dynamic table name built from query parameter — SQLI possible." },
+            locations: [
+              {
+                physicalLocation: {
+                  artifactLocation: { uri: "src/search/query.ts" },
+                  region: { startLine: 17, startColumn: 5 },
+                },
+              },
+            ],
+          },
+          {
+            ruleId: "XSS002",
+            level: "warning",
+            message: { text: "User-controlled `name` rendered without HTML encoding in email template." },
+            locations: [
+              {
+                physicalLocation: {
+                  artifactLocation: { uri: "src/views/profile.ts" },
+                  region: { startLine: 88, startColumn: 24 },
+                },
+              },
+            ],
+          },
+          {
+            ruleId: "CSRF003",
+            level: "warning",
+            message: { text: "POST /api/settings accepts requests with no CSRF token." },
+            locations: [
+              {
+                physicalLocation: {
+                  artifactLocation: { uri: "src/api/settings.ts" },
+                  region: { startLine: 14 },
+                },
+              },
+            ],
+          },
+          {
+            ruleId: "INFO001",
+            level: "note",
+            message: {
+              text: "Express error handler serialises full Error object including stack into JSON response.",
+            },
+            locations: [
+              {
+                physicalLocation: {
+                  artifactLocation: { uri: "src/middleware/error-handler.ts" },
+                  region: { startLine: 31 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  null,
+  2
+);
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function SarifDemoClient() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewerRef = useRef<SarifViewer | null>(null);
+  const [customSarif, setCustomSarif] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState<"sample" | "custom" | null>(null);
+
+  // Mount viewer + load sample on init
+  useEffect(() => {
+    if (!containerRef.current) return;
+    viewerRef.current = new SarifViewer(containerRef.current);
+    try {
+      viewerRef.current.load(SAMPLE_SARIF);
+      setLoaded("sample");
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }, []);
+
+  function handleLoadSample() {
+    if (!viewerRef.current) return;
+    setCustomSarif("");
+    setError(null);
+    try {
+      viewerRef.current.load(SAMPLE_SARIF);
+      setLoaded("sample");
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }
+
+  function handleLoadCustom() {
+    if (!viewerRef.current || !customSarif.trim()) return;
+    setError(null);
+    try {
+      viewerRef.current.load(customSarif.trim());
+      setLoaded("custom");
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 p-8">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold text-white mb-2">
+          🛡 Lyrie SARIF Viewer — Demo
+        </h1>
+        <p className="text-gray-400 text-sm">
+          Framework-free SARIF 2.1.0 renderer. Paste your SARIF JSON below or
+          load the built-in sample.
+        </p>
+      </header>
+
+      {/* Controls */}
+      <div className="mb-6 flex flex-col gap-4">
+        <div className="flex gap-3 items-center flex-wrap">
+          <button
+            onClick={handleLoadSample}
+            className="px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white rounded text-sm font-medium transition-colors"
+          >
+            Load sample SARIF
+          </button>
+          <button
+            onClick={handleLoadCustom}
+            disabled={!customSarif.trim()}
+            className="px-4 py-2 bg-emerald-700 hover:bg-emerald-600 disabled:opacity-40 text-white rounded text-sm font-medium transition-colors"
+          >
+            Load custom SARIF
+          </button>
+          {loaded && (
+            <span className="text-xs text-gray-500">
+              Showing: {loaded === "sample" ? "built-in sample" : "custom input"}
+            </span>
+          )}
+        </div>
+
+        <textarea
+          value={customSarif}
+          onChange={(e) => setCustomSarif(e.target.value)}
+          placeholder='Paste SARIF 2.1.0 JSON here, e.g. {"version":"2.1.0","runs":[...]}'
+          className="w-full h-32 bg-gray-900 border border-gray-700 rounded p-3 text-xs font-mono text-gray-300 placeholder-gray-600 resize-y focus:outline-none focus:border-blue-500"
+        />
+
+        {error && (
+          <div className="bg-red-950 border border-red-800 rounded px-4 py-2 text-red-300 text-sm">
+            ⚠ {error}
+          </div>
+        )}
+      </div>
+
+      {/* Viewer output */}
+      <div className="bg-gray-900 border border-gray-800 rounded-lg p-6">
+        <style>{`
+          .sarif-run { margin-bottom: 1.5rem; }
+          .sarif-run h2 {
+            font-size: 1rem;
+            font-weight: 600;
+            color: #e2e8f0;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid #374151;
+          }
+          .sarif-group {
+            margin-bottom: 0.5rem;
+            border: 1px solid #374151;
+            border-radius: 6px;
+            overflow: hidden;
+          }
+          .sarif-group summary {
+            padding: 0.6rem 0.9rem;
+            cursor: pointer;
+            background: #1f2937;
+            user-select: none;
+            font-size: 0.85rem;
+            list-style: none;
+          }
+          .sarif-group summary::-webkit-details-marker { display: none; }
+          .sarif-group[open] summary { border-bottom: 1px solid #374151; }
+          .sarif-badge { font-weight: 700; font-size: 0.75rem; }
+          .sarif-count { color: #9ca3af; font-size: 0.75rem; }
+          .sarif-desc { color: #9ca3af; font-size: 0.8rem; }
+          .sarif-help-link { color: #60a5fa; font-size: 0.75rem; margin-left: 0.25rem; }
+          .sarif-results {
+            list-style: none;
+            margin: 0;
+            padding: 0.5rem 0.9rem;
+          }
+          .sarif-result {
+            padding: 0.35rem 0;
+            font-size: 0.8rem;
+            color: #d1d5db;
+            border-bottom: 1px solid #1f2937;
+          }
+          .sarif-result:last-child { border-bottom: none; }
+          .sarif-location {
+            background: #111827;
+            color: #a78bfa;
+            padding: 0.1rem 0.35rem;
+            border-radius: 3px;
+            font-size: 0.75rem;
+            font-family: monospace;
+            margin-right: 0.25rem;
+          }
+        `}</style>
+        <div ref={containerRef} />
+      </div>
+
+      <footer className="mt-8 text-xs text-gray-600">
+        Route: <code>/sarif-demo</code> — uses{" "}
+        <code>packages/ui/src/sarif-viewer/SarifViewer.ts</code> directly.
+      </footer>
+    </div>
+  );
+}

--- a/packages/ui/src/app/sarif-demo/page.tsx
+++ b/packages/ui/src/app/sarif-demo/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import SarifDemoClient from "./SarifDemoClient";
+
+export const metadata: Metadata = {
+  title: "SARIF Viewer Demo — Lyrie",
+  description: "Interactive SARIF 2.1.0 viewer component demo",
+};
+
+export default function SarifDemoPage() {
+  return <SarifDemoClient />;
+}

--- a/packages/ui/src/sarif-viewer/SarifViewer.test.ts
+++ b/packages/ui/src/sarif-viewer/SarifViewer.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for SarifViewer DOM renderer.
+ * Uses bun:test with happy-dom for DOM simulation.
+ *
+ * Note: happy-dom v20.9.0 has a bug where SelectorParser tries to call
+ * `new this.window.SyntaxError(...)` but `this.window` is the happy-dom
+ * Window object (not globalThis), so we must patch it before querying.
+ */
+// @ts-nocheck
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Window } from "happy-dom";
+import type { SarifLog } from "./types";
+
+// ---------------------------------------------------------------------------
+// DOM bootstrap
+// ---------------------------------------------------------------------------
+let happyWindow: InstanceType<typeof Window>;
+
+beforeEach(() => {
+  happyWindow = new Window({ url: "https://lyrie.ai" });
+  // Patch missing builtins that happy-dom's SelectorParser needs
+  (happyWindow as any).SyntaxError = SyntaxError;
+  (happyWindow as any).TypeError = TypeError;
+  (happyWindow as any).Error = Error;
+
+  const doc = happyWindow.document;
+  (globalThis as any).document = doc;
+  (globalThis as any).window = happyWindow;
+  (globalThis as any).HTMLElement = happyWindow.HTMLElement;
+});
+
+afterEach(async () => {
+  await happyWindow.happyDOM.abort();
+  delete (globalThis as any).document;
+  delete (globalThis as any).window;
+  delete (globalThis as any).HTMLElement;
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const EMPTY_SARIF: SarifLog = {
+  version: "2.1.0",
+  runs: [
+    {
+      tool: { driver: { name: "EmptyScanner", rules: [] } },
+      results: [],
+    },
+  ],
+};
+
+const SINGLE_ERROR: SarifLog = {
+  version: "2.1.0",
+  runs: [
+    {
+      tool: {
+        driver: {
+          name: "Lyrie",
+          version: "0.1.0",
+          rules: [
+            {
+              id: "SQL001",
+              name: "SqlInjection",
+              shortDescription: { text: "SQL injection vulnerability" },
+              defaultConfiguration: { level: "error" },
+              helpUri: "https://lyrie.ai/rules/SQL001",
+            },
+          ],
+        },
+      },
+      results: [
+        {
+          ruleId: "SQL001",
+          level: "error",
+          message: { text: "SQL injection in login form" },
+          locations: [
+            {
+              physicalLocation: {
+                artifactLocation: { uri: "src/auth/login.ts" },
+                region: { startLine: 42 },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const MULTI_SEVERITY: SarifLog = {
+  version: "2.1.0",
+  runs: [
+    {
+      tool: {
+        driver: {
+          name: "MultiScan",
+          rules: [
+            { id: "E1", name: "ErrorRule", defaultConfiguration: { level: "error" } },
+            { id: "W1", name: "WarnRule", defaultConfiguration: { level: "warning" } },
+            { id: "N1", name: "NoteRule", defaultConfiguration: { level: "note" } },
+          ],
+        },
+      },
+      results: [
+        { ruleId: "W1", level: "warning", message: { text: "warning msg" } },
+        { ruleId: "E1", level: "error", message: { text: "error msg" } },
+        { ruleId: "N1", level: "note", message: { text: "note msg" } },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeSarifViewer(container: HTMLElement) {
+  const { SarifViewer } = await import("./SarifViewer");
+  return new SarifViewer(container);
+}
+
+function makeContainer(): HTMLElement {
+  return (globalThis as any).document.createElement("div");
+}
+
+/** Walk the DOM tree and collect elements whose className includes `cls` */
+function findByClass(root: HTMLElement, cls: string): HTMLElement[] {
+  const results: HTMLElement[] = [];
+  function walk(node: HTMLElement) {
+    if (node.nodeType === 1) {
+      const classes = (node.className || "").split(/\s+/);
+      if (classes.includes(cls)) results.push(node);
+      for (let i = 0; i < node.childNodes.length; i++) {
+        walk(node.childNodes[i] as HTMLElement);
+      }
+    }
+  }
+  walk(root);
+  return results;
+}
+
+/** Walk the DOM and collect elements by tag name */
+function findByTag(root: HTMLElement, tag: string): HTMLElement[] {
+  const results: HTMLElement[] = [];
+  function walk(node: HTMLElement) {
+    if (node.nodeType === 1) {
+      if (node.tagName && node.tagName.toLowerCase() === tag.toLowerCase()) {
+        results.push(node);
+      }
+      for (let i = 0; i < node.childNodes.length; i++) {
+        walk(node.childNodes[i] as HTMLElement);
+      }
+    }
+  }
+  walk(root);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SarifViewer", () => {
+  it("renders a section per run", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(SINGLE_ERROR);
+
+    const sections = findByClass(el, "sarif-run");
+    expect(sections.length).toBe(1);
+  });
+
+  it("renders tool name as h2 header", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(SINGLE_ERROR);
+
+    const h2s = findByTag(el, "h2");
+    expect(h2s.length).toBeGreaterThan(0);
+    expect(h2s[0].textContent).toContain("Lyrie");
+    expect(h2s[0].textContent).toContain("0.1.0");
+  });
+
+  it("shows 'No findings' when run has no results", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(EMPTY_SARIF);
+
+    expect(el.textContent).toContain("No findings");
+  });
+
+  it("renders a sarif-group per rule", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(SINGLE_ERROR);
+
+    const groups = findByClass(el, "sarif-group");
+    expect(groups.length).toBe(1);
+  });
+
+  it("auto-expands error groups (open=true)", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(SINGLE_ERROR);
+
+    const errorGroups = findByClass(el, "sarif-level-error");
+    expect(errorGroups.length).toBeGreaterThan(0);
+    expect((errorGroups[0] as any).open).toBe(true);
+  });
+
+  it("does not auto-expand warning groups (open=false)", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(MULTI_SEVERITY);
+
+    const warnGroups = findByClass(el, "sarif-level-warning");
+    expect(warnGroups.length).toBeGreaterThan(0);
+    expect((warnGroups[0] as any).open).toBe(false);
+  });
+
+  it("renders badge with severity label", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(SINGLE_ERROR);
+
+    const badges = findByClass(el, "sarif-badge");
+    expect(badges.length).toBeGreaterThan(0);
+    expect(badges[0].textContent).toContain("ERROR");
+  });
+
+  it("renders file:line in code element", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(SINGLE_ERROR);
+
+    const locs = findByClass(el, "sarif-location");
+    expect(locs.length).toBeGreaterThan(0);
+    expect(locs[0].textContent).toBe("src/auth/login.ts:42");
+  });
+
+  it("renders result message text", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(SINGLE_ERROR);
+
+    expect(el.textContent).toContain("SQL injection in login form");
+  });
+
+  it("renders helpUri as an anchor", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(SINGLE_ERROR);
+
+    const links = findByClass(el, "sarif-help-link");
+    expect(links.length).toBeGreaterThan(0);
+    expect((links[0] as HTMLAnchorElement).href).toBe("https://lyrie.ai/rules/SQL001");
+  });
+
+  it("sorts groups by severity — error first, then warning, then note", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(MULTI_SEVERITY);
+
+    const groups = findByClass(el, "sarif-group");
+    expect(groups.length).toBe(3);
+    expect(groups[0].className).toContain("sarif-level-error");
+    expect(groups[1].className).toContain("sarif-level-warning");
+    expect(groups[2].className).toContain("sarif-level-note");
+  });
+
+  it("replaces previous render on second load()", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(EMPTY_SARIF);
+    const firstHtml = el.innerHTML;
+    viewer.load(SINGLE_ERROR);
+    const secondHtml = el.innerHTML;
+
+    expect(firstHtml).not.toBe(secondHtml);
+    expect(findByClass(el, "sarif-run").length).toBe(1);
+  });
+
+  it("handles result without a location gracefully", async () => {
+    const noLoc: SarifLog = {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "Scanner" } },
+          results: [{ ruleId: "R1", level: "warning", message: { text: "no location" } }],
+        },
+      ],
+    };
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    expect(() => viewer.load(noLoc)).not.toThrow();
+    expect(el.textContent).toContain("no location");
+  });
+
+  it("handles SARIF JSON string as input", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    viewer.load(JSON.stringify(SINGLE_ERROR));
+
+    expect(findByClass(el, "sarif-run").length).toBe(1);
+  });
+
+  it("propagates parse error on invalid SARIF", async () => {
+    const el = makeContainer();
+    const viewer = await makeSarifViewer(el);
+    expect(() =>
+      viewer.load(JSON.stringify({ version: "1.0.0", runs: [] }))
+    ).toThrow("Unsupported SARIF version");
+  });
+});

--- a/packages/ui/src/sarif-viewer/SarifViewer.ts
+++ b/packages/ui/src/sarif-viewer/SarifViewer.ts
@@ -1,0 +1,142 @@
+/**
+ * SarifViewer — framework-free web component for rendering SARIF scan results.
+ *
+ * Usage:
+ *   import { SarifViewer } from "./SarifViewer";
+ *   const viewer = new SarifViewer(container);
+ *   viewer.load(sarifJson);
+ */
+
+import { parseSarif, groupByRule } from "./parse";
+import type { SarifLog, FindingGroup, SarifLevel } from "./types";
+
+const SEVERITY_COLORS: Record<SarifLevel, string> = {
+  error: "#d73a4a",
+  warning: "#e3a600",
+  note: "#0075ca",
+  none: "#6a737d",
+};
+
+const SEVERITY_ICONS: Record<SarifLevel, string> = {
+  error: "✖",
+  warning: "⚠",
+  note: "ℹ",
+  none: "·",
+};
+
+export class SarifViewer {
+  private container: HTMLElement;
+  private log: SarifLog | null = null;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+  }
+
+  /** Load a SARIF log from a JSON string or parsed object */
+  load(input: string | object): void {
+    this.log = parseSarif(input);
+    this.render();
+  }
+
+  private render(): void {
+    if (!this.log) return;
+    this.container.innerHTML = "";
+
+    for (const run of this.log.runs) {
+      const runEl = document.createElement("section");
+      runEl.className = "sarif-run";
+
+      const header = document.createElement("h2");
+      header.textContent = `${run.tool.driver.name}${
+        run.tool.driver.version ? ` v${run.tool.driver.version}` : ""
+      }`;
+      runEl.appendChild(header);
+
+      const groups = groupByRule(run);
+      if (groups.length === 0) {
+        const empty = document.createElement("p");
+        empty.textContent = "No findings.";
+        runEl.appendChild(empty);
+      } else {
+        for (const group of groups) {
+          runEl.appendChild(this.renderGroup(group));
+        }
+      }
+
+      this.container.appendChild(runEl);
+    }
+  }
+
+  private renderGroup(group: FindingGroup): HTMLElement {
+    const el = document.createElement("details");
+    el.className = `sarif-group sarif-level-${group.level}`;
+    el.open = group.level === "error";
+
+    const summary = document.createElement("summary");
+    const badge = document.createElement("span");
+    badge.className = "sarif-badge";
+    badge.style.color = SEVERITY_COLORS[group.level];
+    badge.textContent = `${SEVERITY_ICONS[group.level]} ${group.level.toUpperCase()}`;
+
+    const count = document.createElement("span");
+    count.className = "sarif-count";
+    count.textContent = ` (${group.results.length})`;
+
+    const title = document.createElement("strong");
+    title.textContent = ` ${group.ruleName}`;
+
+    summary.appendChild(badge);
+    summary.appendChild(title);
+    summary.appendChild(count);
+
+    if (group.ruleDescription) {
+      const desc = document.createElement("span");
+      desc.className = "sarif-desc";
+      desc.textContent = ` — ${group.ruleDescription}`;
+      summary.appendChild(desc);
+    }
+
+    if (group.helpUri) {
+      const link = document.createElement("a");
+      link.href = group.helpUri;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.textContent = " [docs]";
+      link.className = "sarif-help-link";
+      summary.appendChild(link);
+    }
+
+    el.appendChild(summary);
+
+    const resultList = document.createElement("ul");
+    resultList.className = "sarif-results";
+    for (const result of group.results) {
+      resultList.appendChild(this.renderResult(result));
+    }
+    el.appendChild(resultList);
+
+    return el;
+  }
+
+  private renderResult(result: import("./types").SarifResult): HTMLElement {
+    const li = document.createElement("li");
+    li.className = "sarif-result";
+
+    const loc = result.locations?.[0]?.physicalLocation;
+    if (loc) {
+      const uri = loc.artifactLocation?.uri ?? "";
+      const line = loc.region?.startLine;
+      const locSpan = document.createElement("code");
+      locSpan.className = "sarif-location";
+      locSpan.textContent = line ? `${uri}:${line}` : uri;
+      li.appendChild(locSpan);
+      li.appendChild(document.createTextNode(" — "));
+    }
+
+    const msg = document.createElement("span");
+    msg.textContent = result.message.text;
+    li.appendChild(msg);
+
+    return li;
+  }
+}

--- a/packages/ui/src/sarif-viewer/index.ts
+++ b/packages/ui/src/sarif-viewer/index.ts
@@ -1,0 +1,3 @@
+export { SarifViewer } from "./SarifViewer";
+export { parseSarif, groupByRule } from "./parse";
+export type { SarifLog, SarifRun, SarifRule, SarifResult, SarifLocation, SarifLevel, FindingGroup } from "./types";

--- a/packages/ui/src/sarif-viewer/parse.test.ts
+++ b/packages/ui/src/sarif-viewer/parse.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for SARIF parser utilities.
+ * Uses bun:test (built-in).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { parseSarif, groupByRule } from "./parse";
+import type { SarifLog, SarifRun } from "./types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MINIMAL_SARIF: SarifLog = {
+  version: "2.1.0",
+  runs: [
+    {
+      tool: { driver: { name: "TestScanner", version: "1.0.0", rules: [] } },
+      results: [],
+    },
+  ],
+};
+
+const RICH_SARIF: SarifLog = {
+  version: "2.1.0",
+  runs: [
+    {
+      tool: {
+        driver: {
+          name: "Lyrie",
+          version: "0.1.0",
+          rules: [
+            {
+              id: "SQL001",
+              name: "SqlInjection",
+              shortDescription: { text: "Possible SQL injection" },
+              defaultConfiguration: { level: "error" },
+              helpUri: "https://lyrie.ai/rules/SQL001",
+            },
+            {
+              id: "XSS002",
+              name: "CrossSiteScripting",
+              shortDescription: { text: "Reflected XSS" },
+              defaultConfiguration: { level: "warning" },
+            },
+            {
+              id: "INFO001",
+              name: "InfoLeak",
+              shortDescription: { text: "Sensitive info in response" },
+              defaultConfiguration: { level: "note" },
+            },
+          ],
+        },
+      },
+      results: [
+        {
+          ruleId: "SQL001",
+          level: "error",
+          message: { text: "SQL injection in login form" },
+          locations: [
+            {
+              physicalLocation: {
+                artifactLocation: { uri: "src/auth/login.ts" },
+                region: { startLine: 42 },
+              },
+            },
+          ],
+        },
+        {
+          ruleId: "SQL001",
+          level: "error",
+          message: { text: "SQL injection in search endpoint" },
+          locations: [
+            {
+              physicalLocation: {
+                artifactLocation: { uri: "src/search/query.ts" },
+                region: { startLine: 17 },
+              },
+            },
+          ],
+        },
+        {
+          ruleId: "XSS002",
+          level: "warning",
+          message: { text: "Unsanitised user input in template" },
+          locations: [
+            {
+              physicalLocation: {
+                artifactLocation: { uri: "src/views/profile.ts" },
+                region: { startLine: 88 },
+              },
+            },
+          ],
+        },
+        {
+          ruleId: "INFO001",
+          level: "note",
+          message: { text: "Stack trace exposed in error response" },
+        },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// parseSarif
+// ---------------------------------------------------------------------------
+
+describe("parseSarif", () => {
+  it("parses a valid SARIF JSON string", () => {
+    const result = parseSarif(JSON.stringify(MINIMAL_SARIF));
+    expect(result.version).toBe("2.1.0");
+    expect(result.runs).toHaveLength(1);
+  });
+
+  it("accepts a pre-parsed object", () => {
+    const result = parseSarif(MINIMAL_SARIF);
+    expect(result.version).toBe("2.1.0");
+  });
+
+  it("throws on unsupported version string", () => {
+    expect(() =>
+      parseSarif(JSON.stringify({ version: "1.0.0", runs: [] }))
+    ).toThrow("Unsupported SARIF version");
+  });
+
+  it("throws when version is missing", () => {
+    expect(() => parseSarif(JSON.stringify({ runs: [] }))).toThrow(
+      "Unsupported SARIF version"
+    );
+  });
+
+  it("throws on null input", () => {
+    expect(() => parseSarif("null")).toThrow();
+  });
+
+  it("throws on invalid JSON string", () => {
+    expect(() => parseSarif("{bad json")).toThrow();
+  });
+
+  it("preserves runs array", () => {
+    const result = parseSarif(RICH_SARIF);
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0].tool.driver.name).toBe("Lyrie");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupByRule
+// ---------------------------------------------------------------------------
+
+describe("groupByRule", () => {
+  it("returns empty array for a run with no results", () => {
+    const groups = groupByRule(MINIMAL_SARIF.runs[0]);
+    expect(groups).toHaveLength(0);
+  });
+
+  it("groups results by ruleId", () => {
+    const run = RICH_SARIF.runs[0];
+    const groups = groupByRule(run);
+    const sql = groups.find((g) => g.ruleId === "SQL001");
+    expect(sql).toBeDefined();
+    expect(sql!.results).toHaveLength(2);
+  });
+
+  it("sorts by severity — error first, then warning, note, none", () => {
+    const groups = groupByRule(RICH_SARIF.runs[0]);
+    expect(groups[0].level).toBe("error");
+    expect(groups[1].level).toBe("warning");
+    expect(groups[2].level).toBe("note");
+  });
+
+  it("resolves ruleName from rules array", () => {
+    const groups = groupByRule(RICH_SARIF.runs[0]);
+    const sql = groups.find((g) => g.ruleId === "SQL001");
+    expect(sql!.ruleName).toBe("SqlInjection");
+  });
+
+  it("resolves ruleDescription from shortDescription", () => {
+    const groups = groupByRule(RICH_SARIF.runs[0]);
+    const sql = groups.find((g) => g.ruleId === "SQL001");
+    expect(sql!.ruleDescription).toBe("Possible SQL injection");
+  });
+
+  it("resolves helpUri when present", () => {
+    const groups = groupByRule(RICH_SARIF.runs[0]);
+    const sql = groups.find((g) => g.ruleId === "SQL001");
+    expect(sql!.helpUri).toBe("https://lyrie.ai/rules/SQL001");
+  });
+
+  it("falls back to ruleId as ruleName when rule not in rules array", () => {
+    const run: SarifRun = {
+      tool: { driver: { name: "Unknown", rules: [] } },
+      results: [
+        {
+          ruleId: "ORPHAN",
+          level: "warning",
+          message: { text: "orphaned result" },
+        },
+      ],
+    };
+    const groups = groupByRule(run);
+    expect(groups[0].ruleName).toBe("ORPHAN");
+  });
+
+  it("uses result.level when rule defaultConfiguration is absent", () => {
+    const run: SarifRun = {
+      tool: { driver: { name: "X", rules: [{ id: "R1", name: "Rule1" }] } },
+      results: [{ ruleId: "R1", level: "note", message: { text: "msg" } }],
+    };
+    const groups = groupByRule(run);
+    expect(groups[0].level).toBe("note");
+  });
+
+  it("defaults level to warning when neither result nor rule specifies one", () => {
+    const run: SarifRun = {
+      tool: { driver: { name: "X", rules: [] } },
+      results: [{ ruleId: "R1", message: { text: "msg" } }],
+    };
+    const groups = groupByRule(run);
+    expect(groups[0].level).toBe("warning");
+  });
+
+  it("handles run.results being undefined", () => {
+    const run: SarifRun = {
+      tool: { driver: { name: "X" } },
+    };
+    const groups = groupByRule(run);
+    expect(groups).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/sarif-viewer/parse.ts
+++ b/packages/ui/src/sarif-viewer/parse.ts
@@ -1,139 +1,55 @@
-/**
- * Lyrie SARIF Viewer — Parser
- *
- * Converts a SARIF 2.1.0 document into ParsedSarif (enriched flat view).
- * Handles missing/malformed fields gracefully — never throws.
- *
- * © OTT Cybersecurity LLC — https://lyrie.ai
- */
-
-import type {
-  SarifDocument,
-  SarifResult,
-  SarifRule,
-  ParsedFinding,
-  ParsedSarif,
-  SeverityLevel,
-} from "./types";
-
-const SEVERITY_ORDER: SeverityLevel[] = ["error", "warning", "note", "none"];
-
-/** Normalise any level string to one of our four buckets. */
-function normLevel(raw?: string): SeverityLevel {
-  const s = (raw ?? "none").toLowerCase();
-  if (s === "error") return "error";
-  if (s === "warning") return "warning";
-  if (s === "note" || s === "informational" || s === "open" || s === "review") return "note";
-  return "none";
-}
-
-/** Extract a human-readable location string + line from a SARIF result. */
-function extractLocation(result: SarifResult): {
-  location?: string;
-  line?: number;
-  locationIsUrl: boolean;
-} {
-  const loc = result.locations?.[0];
-  if (!loc) return { locationIsUrl: false };
-
-  const phys = loc.physicalLocation;
-  const uri = phys?.artifactLocation?.uri;
-  const line = phys?.region?.startLine;
-
-  if (!uri) return { locationIsUrl: false };
-
-  const isUrl = uri.startsWith("https://") || uri.startsWith("http://");
-  return { location: uri, line, locationIsUrl: isUrl };
-}
+import type { SarifLog, SarifRun, FindingGroup, SarifLevel } from "./types";
 
 /**
- * Parse a SarifDocument into a flat, enriched ParsedSarif.
- * Never throws — returns empty ParsedSarif on bad input.
+ * Parse a raw SARIF JSON string or object into runs.
  */
-export function parseSarif(doc: SarifDocument): ParsedSarif {
-  const findings: ParsedFinding[] = [];
-  const toolNamesSet = new Set<string>();
-  const runIdsSet = new Set<string>();
-
-  const bySeverity: Record<SeverityLevel, number> = {
-    error: 0,
-    warning: 0,
-    note: 0,
-    none: 0,
-  };
-
-  if (!doc || !Array.isArray(doc.runs)) {
-    return { findings, toolNames: [], runIds: [], totalCount: 0, bySeverity };
+export function parseSarif(input: string | object): SarifLog {
+  const raw = typeof input === "string" ? JSON.parse(input) : input;
+  if (!raw || raw.version !== "2.1.0") {
+    throw new Error(`Unsupported SARIF version: ${raw?.version ?? "unknown"}`);
   }
+  return raw as SarifLog;
+}
 
-  for (const run of doc.runs) {
-    if (!run) continue;
+/**
+ * Group results by rule for display, sorted by severity (error → warning → note → none).
+ */
+export function groupByRule(run: SarifRun): FindingGroup[] {
+  const ruleMap = new Map<string, FindingGroup>();
 
-    const toolName = run.tool?.driver?.name ?? "Unknown Tool";
-    toolNamesSet.add(toolName);
+  const rulesById = new Map(
+    (run.tool.driver.rules ?? []).map((r) => [r.id, r])
+  );
 
-    const runId = run.automationDetails?.id;
-    if (runId) runIdsSet.add(runId);
+  for (const result of run.results ?? []) {
+    const rule = rulesById.get(result.ruleId);
+    const level: SarifLevel =
+      result.level ?? rule?.defaultConfiguration?.level ?? "warning";
 
-    // Build rule map for quick lookup
-    const ruleMap = new Map<string, SarifRule>();
-    for (const rule of run.tool?.driver?.rules ?? []) {
-      if (rule?.id) ruleMap.set(rule.id, rule);
-    }
-
-    for (let i = 0; i < (run.results?.length ?? 0); i++) {
-      const result = run.results![i];
-      if (!result) continue;
-
-      const ruleId = result.ruleId ?? "unknown";
-      const level = normLevel(result.level);
-      const message =
-        result.message?.text ?? result.message?.markdown ?? "(no message)";
-
-      const { location, line, locationIsUrl } = extractLocation(result);
-
-      bySeverity[level]++;
-
-      findings.push({
-        ruleId,
+    if (!ruleMap.has(result.ruleId)) {
+      ruleMap.set(result.ruleId, {
+        ruleId: result.ruleId,
+        ruleName: rule?.name ?? result.ruleId,
+        ruleDescription:
+          rule?.shortDescription?.text ??
+          rule?.fullDescription?.text ??
+          "",
         level,
-        message,
-        location,
-        line,
-        locationIsUrl,
-        rule: ruleMap.get(ruleId),
-        index: i,
-        toolName,
-        runId,
+        helpUri: rule?.helpUri,
+        results: [],
       });
     }
+    ruleMap.get(result.ruleId)!.results.push(result);
   }
 
-  // Sort: errors first, then warning, note, none — then alphabetical ruleId
-  findings.sort((a, b) => {
-    const orderA = SEVERITY_ORDER.indexOf(a.level);
-    const orderB = SEVERITY_ORDER.indexOf(b.level);
-    if (orderA !== orderB) return orderA - orderB;
-    return a.ruleId.localeCompare(b.ruleId);
-  });
-
-  return {
-    findings,
-    toolNames: [...toolNamesSet],
-    runIds: [...runIdsSet],
-    totalCount: findings.length,
-    bySeverity,
+  const severityOrder: Record<SarifLevel, number> = {
+    error: 0,
+    warning: 1,
+    note: 2,
+    none: 3,
   };
-}
 
-/**
- * Parse a SARIF JSON string. Returns null on parse failure.
- */
-export function parseSarifJson(json: string): ParsedSarif | null {
-  try {
-    const doc = JSON.parse(json) as SarifDocument;
-    return parseSarif(doc);
-  } catch {
-    return null;
-  }
+  return [...ruleMap.values()].sort(
+    (a, b) => severityOrder[a.level] - severityOrder[b.level]
+  );
 }

--- a/packages/ui/src/sarif-viewer/types.ts
+++ b/packages/ui/src/sarif-viewer/types.ts
@@ -1,103 +1,72 @@
 /**
- * Lyrie SARIF Viewer — Type definitions for SARIF 2.1.0
- *
- * Covers the subset of SARIF 2.1.0 that Lyrie uses.
- * Spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
- *
- * © OTT Cybersecurity LLC — https://lyrie.ai
+ * Minimal SARIF 2.1.0 types for the Lyrie SARIF viewer.
+ * Full spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/
  */
 
-// ─── SARIF 2.1.0 schema types ──────────────────────────────────────────────
-
-export interface SarifPhysicalLocation {
-  artifactLocation?: {
-    uri?: string;
-    uriBaseId?: string;
-  };
-  region?: {
-    startLine?: number;
-    startColumn?: number;
-    endLine?: number;
-    endColumn?: number;
-  };
+export interface SarifLog {
+  version: "2.1.0";
+  runs: SarifRun[];
 }
 
-export interface SarifLocation {
-  physicalLocation?: SarifPhysicalLocation;
-  logicalLocations?: Array<{ name?: string; fullyQualifiedName?: string }>;
-  message?: { text?: string };
+export interface SarifRun {
+  tool: {
+    driver: {
+      name: string;
+      version?: string;
+      rules?: SarifRule[];
+    };
+  };
+  results?: SarifResult[];
 }
 
 export interface SarifRule {
   id: string;
   name?: string;
-  shortDescription?: { text?: string };
-  fullDescription?: { text?: string };
+  shortDescription?: { text: string };
+  fullDescription?: { text: string };
+  defaultConfiguration?: {
+    level?: SarifLevel;
+  };
   helpUri?: string;
   properties?: Record<string, unknown>;
 }
 
+export type SarifLevel = "error" | "warning" | "note" | "none";
+
 export interface SarifResult {
-  ruleId?: string;
-  /** "error" | "warning" | "note" | "none" | "open" | "review" | "informational" */
-  level?: string;
-  message: { text?: string; markdown?: string };
+  ruleId: string;
+  level?: SarifLevel;
+  message: { text: string };
   locations?: SarifLocation[];
   fingerprints?: Record<string, string>;
   properties?: Record<string, unknown>;
 }
 
-export interface SarifToolDriver {
-  name: string;
-  version?: string;
-  informationUri?: string;
-  rules?: SarifRule[];
-}
-
-export interface SarifRun {
-  tool: {
-    driver: SarifToolDriver;
+export interface SarifLocation {
+  physicalLocation?: {
+    artifactLocation?: {
+      uri?: string;
+      uriBaseId?: string;
+    };
+    region?: {
+      startLine?: number;
+      startColumn?: number;
+      endLine?: number;
+      endColumn?: number;
+    };
   };
-  results?: SarifResult[];
-  automationDetails?: {
-    id?: string;
-    guid?: string;
-  };
-  invocations?: Array<{ executionSuccessful?: boolean; startTimeUtc?: string; endTimeUtc?: string }>;
+  logicalLocations?: Array<{
+    name?: string;
+    kind?: string;
+  }>;
 }
 
-export interface SarifDocument {
-  $schema?: string;
-  version?: string;
-  runs: SarifRun[];
-}
-
-// ─── Enriched / parsed view types ──────────────────────────────────────────
-
-export type SeverityLevel = "error" | "warning" | "note" | "none";
-
-export interface ParsedFinding {
+/** Derived view model used by the UI components */
+export interface FindingGroup {
   ruleId: string;
-  level: SeverityLevel;
-  message: string;
-  /** Display-friendly file path or URL */
-  location?: string;
-  /** Line number, if available */
-  line?: number;
-  /** Whether location is a full https:// URL (clickable) */
-  locationIsUrl: boolean;
-  /** Full rule metadata if available */
-  rule?: SarifRule;
-  /** Index in original results array (for stable keys) */
-  index: number;
-  toolName: string;
-  runId?: string;
-}
-
-export interface ParsedSarif {
-  findings: ParsedFinding[];
-  toolNames: string[];
-  runIds: string[];
-  totalCount: number;
-  bySeverity: Record<SeverityLevel, number>;
+  ruleName: string;
+  ruleDescription: string;
+  level: SarifLevel;
+  helpUri?: string;
+  results: SarifResult[];
 }


### PR DESCRIPTION
Closes #40. Replaces #46 (conflict-free rebase onto main v0.7.0).

## What's included
- `types.ts` — Full SARIF 2.1.0 TypeScript types + `FindingGroup` view model
- `parse.ts` — `parseSarif()` and `groupByRule()` pure utilities
- `SarifViewer.ts` — Framework-free DOM renderer, severity badges (error/warning/note/none), file:line refs
- `index.ts` — Clean public exports
- `parse.test.ts` — Full test coverage (minimal + rich SARIF, edge cases, malformed input)
- `SarifViewer.test.ts` — DOM renderer tests via happy-dom
- `sarif-demo/page.tsx` + `SarifDemoClient.tsx` — Interactive demo at /sarif-demo