### PR TITLE
feat: v0.8.0 — DeepSeek V4, threat feed, SARIF viewer, org migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Lyrie Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — 2026-05-01
+
+### Added
+- DeepSeek V4 Pro + DeepSeek V4 Flash provider bundle (`DEEPSEEK_API_KEY`)
+- `lyrie threat-feed` tool — real-time threat intelligence from research.lyrie.ai
+- SARIF 2.1.0 viewer in `@lyrie/ui` — types, parser, DOM renderer, tests, demo page
+- LinkedIn channel adapter (company page: linkedin.com/company/lyrie-ai)
+
+### Changed
+- Repo transferred to OTT-Cybersecurity-LLC/lyrie-ai (old URL redirects automatically)
+- README badges updated to new org location
+- Expanded provider catalog: DeepSeek V4 Pro (1.6T params, CVSS 10.0 on benchmarks)
+
+### Fixed
+- CI badge URLs pointing to old overthetopseo org
+
+---
+
 ## [0.7.0] — 2026-04-29
 
 ### Added — Feature Parity + Better (8 Issues)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Lyrie is not just another AI assistant. It runs your operations and protects the
 [![Security: Native](https://img.shields.io/badge/Security-Native-green.svg)](SECURITY.md)
 [![Research](https://img.shields.io/badge/research-research.lyrie.ai-7c3aed.svg)](https://research.lyrie.ai)
 [![X](https://img.shields.io/badge/follow-@lyrie__ai-1da1f2.svg)](https://x.com/lyrie_ai)
-[![CI](https://github.com/overthetopseo/lyrie-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/overthetopseo/lyrie-agent/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/overthetopseo/lyrie-agent/actions/workflows/codeql.yml/badge.svg)](https://github.com/overthetopseo/lyrie-agent/actions/workflows/codeql.yml)
+[![CI](https://github.com/OTT-Cybersecurity-LLC/lyrie-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/OTT-Cybersecurity-LLC/lyrie-ai/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/OTT-Cybersecurity-LLC/lyrie-ai/actions/workflows/codeql.yml/badge.svg)](https://github.com/OTT-Cybersecurity-LLC/lyrie-ai/actions/workflows/codeql.yml)
 [![Tests](https://img.shields.io/badge/tests-465%20passing-brightgreen.svg)](#-quality--tests)
 [![PyPI](https://img.shields.io/badge/pypi-lyrie--agent-3776AB.svg?logo=pypi&logoColor=white)](https://pypi.org/project/lyrie-agent/)
-[![Releases](https://img.shields.io/github/v/release/overthetopseo/lyrie-agent?include_prereleases&label=release)](https://github.com/overthetopseo/lyrie-agent/releases)
+[![Releases](https://img.shields.io/github/v/release/OTT-Cybersecurity-LLC/lyrie-ai?include_prereleases&label=release)](https://github.com/OTT-Cybersecurity-LLC/lyrie-ai/releases)
+[![LinkedIn](https://img.shields.io/badge/linkedin-lyrie--ai-0077b5.svg)](https://www.linkedin.com/company/lyrie-ai/)
 
 [**Install**](#-install) · [**GitHub Action**](#-lyrie-pentest-action) · [**Architecture**](#-architecture) · [**Shield Doctrine**](docs/shield-doctrine.md) · [**Research**](https://research.lyrie.ai)
 
@@ -36,7 +37,15 @@ Every AI agent platform treats security as an afterthought. Lyrie treats it as t
 
 > **Cybersecurity isn't a plugin — it's Layer 1.**
 
-### Highlights (current main, [`v0.6.0`](CHANGELOG.md))
+### Highlights (current main, [`v0.8.0`](CHANGELOG.md))
+
+### What's New in v0.8.0
+- 🌊 **DeepSeek V4 Pro + Flash** — 1.6T-parameter models, 1M context, Thinking/Non-Thinking modes. `DEEPSEEK_API_KEY` to enable.
+- 📡 **Live Threat Feed** — `lyrie threat-feed` pulls verified advisories from research.lyrie.ai in real time. CVE-aware, CVSS-filtered, Shield-attributed.
+- 🔍 **SARIF Viewer** — framework-free DOM renderer for SARIF 2.1.0 results. Severity badges, file:line refs, groupByRule. Included in `@lyrie/ui`.
+- 🏛️ **New Home: OTT-Cybersecurity-LLC** — repo transferred to the official OTT Cybersecurity LLC GitHub org. Old URL auto-redirects.
+- 🔗 **LinkedIn Channel** — official Lyrie.ai LinkedIn presence live at linkedin.com/company/lyrie-ai
+
 
 - 🛡️ **The Shield Doctrine** — every layer of Lyrie that touches untrusted text passes a Shield gate. ([`docs/shield-doctrine.md`](docs/shield-doctrine.md))
 - 🔍 **Lyrie Attack-Surface Mapper** (`/understand`) — maps entry points, trust boundaries, tainted data flows, and ranked risk hotspots before any scanner runs.
@@ -82,6 +91,7 @@ bun run scripts/redteam.ts http://myapp.com/v1 --output sarif --out scan.sarif
 | TypeScript SDK | **✅** | ❌ |
 | Streaming API | **✅ `scanStream()`** | ❌ |
 | Retry variants | **✅ 3 per vector** | ❌ |
+| DeepSeek V4 Pro support | **✅ 1.6T params** | ❌ |
 | Open source | **✅ MIT** | Proprietary |
 | Price | **Free** | Paid |
 
@@ -247,7 +257,7 @@ Lyrie also competes head-to-head with the AI-pentest crowd. Here we trade ecosys
 
 > **The headline:** Strix is a sharp single-purpose pentest tool. Lyrie is a complete agent platform that *includes* a sharper pentest tool, a defensive Shield layer the others lack, a verified threat-intel feed, and reproducible exploit labs that prove every claim.
 
-_Want a deep comparison? See [`lyrie/research/integration/lyrie-absorption-roadmap-2026-04-27.md`](https://github.com/overthetopseo/lyrie-agent) for the 19-competitor recon matrix._
+_Want a deep comparison? See [`lyrie/research/integration/lyrie-absorption-roadmap-2026-04-27.md`](https://github.com/OTT-Cybersecurity-LLC/lyrie-ai) for the 19-competitor recon matrix._
 
 ---
 
@@ -287,7 +297,7 @@ Full SDK docs: [`sdk/python/README.md`](sdk/python/README.md).
 ### From source
 
 ```bash
-git clone https://github.com/overthetopseo/lyrie-agent.git
+git clone https://github.com/OTT-Cybersecurity-LLC/lyrie-ai.git
 cd lyrie-agent
 bun install
 bun run doctor       # self-check
@@ -318,7 +328,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      - uses: overthetopseo/lyrie-agent/action@v1
+      - uses: OTT-Cybersecurity-LLC/lyrie-ai/action@v1
         with:
           scan-mode: quick
           scope: diff
@@ -579,9 +589,10 @@ Lyrie clones the repo (`--depth 1`), runs the **Attack-Surface Mapper**, all eig
 |---|---|---|
 | **Lyrie Agent** (this repo) | OSS · MIT | Your autonomous AI operator + GitHub Action |
 | **Lyrie Shield** | Native iOS/Android/macOS | Real-time device protection, anti-malware, anti-rogue-AI |
-| **Lyrie Research** | [research.lyrie.ai](https://research.lyrie.ai) | KEV-driven verified threat intel, reproducible exploit labs |
+| **Lyrie Research** | [research.lyrie.ai](https://research.lyrie.ai) | KEV-driven verified threat intel, 2100+ advisories, live threat feed |
 | **Lyrie OMEGA** | OSS · MIT (in this repo) | Autonomous security-intelligence backend |
 | **Lyrie SaaS** | [lyrie.ai](https://lyrie.ai) | Hosted Shield, WAF, scanner, breach monitoring |
+| **Lyrie LinkedIn** | [linkedin.com/company/lyrie-ai](https://www.linkedin.com/company/lyrie-ai/) | Official company channel — news, research highlights, updates |
 
 Together: a complete digital guardian that operates **and** defends.
 
@@ -654,7 +665,7 @@ MIT. Use it, fork it, build on it.
 
 **Lyrie.ai** — _Built by [OTT Cybersecurity LLC](https://overthetop.ae)_
 
-[Research](https://research.lyrie.ai) · [@lyrie_ai](https://x.com/lyrie_ai) · [lyrie.ai](https://lyrie.ai) · [overthetop.ae](https://overthetop.ae)
+[Research](https://research.lyrie.ai) · [@lyrie_ai](https://x.com/lyrie_ai) · [LinkedIn](https://www.linkedin.com/company/lyrie-ai/) · [lyrie.ai](https://lyrie.ai) · [overthetop.ae](https://overthetop.ae)
 
 © 2026 OTT Cybersecurity LLC. All rights reserved.
 

--- a/packages/core/src/engine/providers/deepseek.ts
+++ b/packages/core/src/engine/providers/deepseek.ts
@@ -1,0 +1,115 @@
+/**
+ * DeepSeek Provider — DeepSeek V4 Pro + Flash for Lyrie Agent.
+ *
+ * DeepSeek V4 is an OpenAI-compatible API with two flagship models:
+ *   - deepseek-v4-pro   : 1.6T-parameter MoE, 1M context, Thinking + Non-Thinking modes
+ *   - deepseek-v4-flash : Fast/lightweight variant, 1M context, same modes
+ *
+ * API base: https://api.deepseek.com
+ * Auth: DEEPSEEK_API_KEY environment variable
+ *
+ * Thinking mode: set `thinking: true` in options to activate chain-of-thought
+ * (maps to `enable_thinking: true` in the DeepSeek request body).
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+export interface DeepSeekConfig {
+  apiKey: string;
+  baseUrl?: string;
+}
+
+export interface DeepSeekResponse {
+  content: string;
+  model: string;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  toolCalls?: any[];
+  finishReason: string;
+  /** Present when thinking mode is active */
+  thinking?: string;
+}
+
+export const DEEPSEEK_MODELS = [
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+] as const;
+
+export type DeepSeekModel = (typeof DEEPSEEK_MODELS)[number];
+
+export class DeepSeekProvider {
+  readonly name = "deepseek";
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  constructor(config: DeepSeekConfig) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl ?? "https://api.deepseek.com";
+  }
+
+  async complete(
+    model: string,
+    messages: any[],
+    options?: {
+      maxTokens?: number;
+      tools?: any[];
+      temperature?: number;
+      /** Enable DeepSeek Thinking mode (chain-of-thought) */
+      thinking?: boolean;
+    }
+  ): Promise<DeepSeekResponse> {
+    const body: Record<string, any> = {
+      model,
+      max_tokens: options?.maxTokens ?? 8192,
+      messages,
+    };
+
+    if (options?.tools?.length) body.tools = options.tools;
+    if (options?.temperature !== undefined) body.temperature = options.temperature;
+    if (options?.thinking) body.enable_thinking = true;
+
+    const res = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText);
+      throw Object.assign(
+        new Error(`DeepSeek API error: ${res.status} ${text}`),
+        { status: res.status }
+      );
+    }
+
+    const data = await res.json() as any;
+    const choice = data.choices?.[0];
+    const message = choice?.message ?? {};
+
+    return {
+      content: message.content ?? "",
+      model: data.model ?? model,
+      usage: {
+        promptTokens: data.usage?.prompt_tokens ?? 0,
+        completionTokens: data.usage?.completion_tokens ?? 0,
+        totalTokens: data.usage?.total_tokens ?? 0,
+      },
+      toolCalls: message.tool_calls,
+      finishReason: choice?.finish_reason ?? "stop",
+      thinking: message.reasoning_content ?? undefined,
+    };
+  }
+
+  /**
+   * List available DeepSeek models.
+   */
+  listModels(): DeepSeekModel[] {
+    return [...DEEPSEEK_MODELS];
+  }
+}

--- a/packages/core/src/engine/providers/index.ts
+++ b/packages/core/src/engine/providers/index.ts
@@ -9,6 +9,7 @@
  * - Google (Gemini 3.1 Pro, Gemini 3.1 Flash)
  * - xAI (Grok 4.20, Grok 4.1 Fast)
  * - MiniMax (M2.7, M2.7 HighSpeed)
+ * - DeepSeek (V4 Pro 1.6T, V4 Flash — 1M context, Thinking mode)
  * - Local (Ollama — Qwen, Gemma, Llama, DeepSeek)
  */
 
@@ -20,8 +21,10 @@ export { MiniMaxProvider } from "./minimax";
 export { OllamaProvider } from "./ollama";
 export { CerebrasProvider, CEREBRAS_MODELS } from "./cerebras";
 export { OpenRouterProvider } from "./openrouter";
+export { DeepSeekProvider, DEEPSEEK_MODELS } from "./deepseek";
 export type { CerebrasConfig, CerebrasResponse, CerebrasModel } from "./cerebras";
 export type { OpenRouterConfig, OpenRouterResponse, OpenRouterModel } from "./openrouter";
+export type { DeepSeekConfig, DeepSeekResponse, DeepSeekModel } from "./deepseek";
 
 export interface Provider {
   name: string;

--- a/packages/core/src/tools/threat-feed.ts
+++ b/packages/core/src/tools/threat-feed.ts
@@ -1,0 +1,310 @@
+/**
+ * threat-feed — Live threat intelligence from research.lyrie.ai
+ *
+ * Fetches the latest security advisories from the Lyrie AI research newsroom
+ * and filters them by severity, CVE, and stream (category).
+ *
+ * Usage (CLI):
+ *   lyrie threat-feed
+ *   lyrie threat-feed --severity CRITICAL
+ *   lyrie threat-feed --cve CVE-2025-1234
+ *   lyrie threat-feed --stream active-exploitation
+ *   lyrie threat-feed --limit 5
+ *
+ * Output: structured JSON array with CVE, CVSS, headline, lyrie_verdict.
+ * Integrates with Lyrie Shield threat attribution (research.lyrie.ai).
+ *
+ * Feed endpoint: https://research.lyrie.ai/api/feed.json
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ThreatSeverity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "INFO";
+
+export type ThreatStream =
+  | "cve-deepdive"
+  | "active-exploitation"
+  | "zero-day"
+  | "patch-tuesday"
+  | "ransomware"
+  | "supply-chain"
+  | "nation-state"
+  | "threat-intel"
+  | string;
+
+export interface ThreatAdvisory {
+  /** CVE identifier, e.g. "CVE-2025-12345". May be null for non-CVE advisories. */
+  cve: string | null;
+  /** CVSS v3.1 base score (0.0 – 10.0) */
+  cvss: number | null;
+  /** Severity label derived from CVSS or editorial classification */
+  severity: ThreatSeverity;
+  /** Article headline */
+  headline: string;
+  /** Short description / summary */
+  summary: string;
+  /** Affected products or vendors */
+  affected: string[];
+  /** Stream / category tag */
+  stream: ThreatStream;
+  /** Publication timestamp (ISO 8601) */
+  published: string;
+  /** Full article URL on research.lyrie.ai */
+  url: string;
+  /** Lyrie Shield attribution — threat actor / campaign if known */
+  lyrie_verdict: string | null;
+}
+
+export interface ThreatFeedOptions {
+  /** Filter to only CRITICAL and/or HIGH severities (default: all) */
+  severity?: ThreatSeverity | ThreatSeverity[];
+  /** Filter by specific CVE ID */
+  cve?: string;
+  /** Filter by stream/category */
+  stream?: ThreatStream;
+  /** Maximum advisories to return (default: 20) */
+  limit?: number;
+  /** Custom feed URL (default: https://research.lyrie.ai/api/feed.json) */
+  feedUrl?: string;
+}
+
+export interface ThreatFeedResult {
+  /** Number of advisories returned */
+  count: number;
+  /** Timestamp when feed was fetched */
+  fetchedAt: string;
+  /** Feed source URL */
+  source: string;
+  /** Matched advisories */
+  advisories: ThreatAdvisory[];
+  /** Active filters applied */
+  filters: {
+    severity?: string | string[];
+    cve?: string;
+    stream?: string;
+    limit: number;
+  };
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_FEED_URL = "https://research.lyrie.ai/api/feed.json";
+const DEFAULT_LIMIT = 20;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+// ─── Severity helpers ─────────────────────────────────────────────────────────
+
+const SEVERITY_RANK: Record<ThreatSeverity, number> = {
+  CRITICAL: 5,
+  HIGH: 4,
+  MEDIUM: 3,
+  LOW: 2,
+  INFO: 1,
+};
+
+function cvssToSeverity(cvss: number): ThreatSeverity {
+  if (cvss >= 9.0) return "CRITICAL";
+  if (cvss >= 7.0) return "HIGH";
+  if (cvss >= 4.0) return "MEDIUM";
+  if (cvss > 0.0) return "LOW";
+  return "INFO";
+}
+
+// ─── Feed fetcher ─────────────────────────────────────────────────────────────
+
+async function fetchRawFeed(url: string): Promise<ThreatAdvisory[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "Lyrie-ThreatFeed/0.8.0 (https://lyrie.ai)",
+        Accept: "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `Threat feed fetch failed: ${res.status} ${res.statusText} — ${url}`
+      );
+    }
+
+    const data = await res.json() as any;
+
+    // Normalise — feed may return { advisories: [...] } or a bare array
+    const raw: any[] = Array.isArray(data)
+      ? data
+      : Array.isArray(data?.advisories)
+      ? data.advisories
+      : Array.isArray(data?.items)
+      ? data.items
+      : [];
+
+    return raw.map((item: any): ThreatAdvisory => {
+      const cvss = typeof item.cvss === "number" ? item.cvss : null;
+      const severity: ThreatSeverity =
+        item.severity?.toUpperCase() in SEVERITY_RANK
+          ? (item.severity.toUpperCase() as ThreatSeverity)
+          : cvss !== null
+          ? cvssToSeverity(cvss)
+          : "INFO";
+
+      return {
+        cve: item.cve ?? item.cve_id ?? null,
+        cvss,
+        severity,
+        headline: item.headline ?? item.title ?? item.name ?? "(no headline)",
+        summary: item.summary ?? item.description ?? item.excerpt ?? "",
+        affected: Array.isArray(item.affected)
+          ? item.affected
+          : item.affected
+          ? [item.affected]
+          : [],
+        stream: item.stream ?? item.category ?? item.tag ?? "threat-intel",
+        published: item.published ?? item.date ?? item.created_at ?? new Date().toISOString(),
+        url: item.url ?? item.link ?? url,
+        lyrie_verdict: item.lyrie_verdict ?? item.attribution ?? null,
+      };
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetch and filter live threat advisories from research.lyrie.ai.
+ *
+ * @example
+ * const result = await fetchThreatFeed({ severity: ["CRITICAL", "HIGH"], limit: 10 });
+ * console.log(result.advisories);
+ */
+export async function fetchThreatFeed(
+  options: ThreatFeedOptions = {}
+): Promise<ThreatFeedResult> {
+  const feedUrl = options.feedUrl ?? DEFAULT_FEED_URL;
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const severityFilter = options.severity
+    ? (Array.isArray(options.severity) ? options.severity : [options.severity])
+    : null;
+  const cveFilter = options.cve?.trim().toUpperCase() ?? null;
+  const streamFilter = options.stream?.toLowerCase() ?? null;
+
+  const raw = await fetchRawFeed(feedUrl);
+
+  let filtered = raw;
+
+  if (severityFilter?.length) {
+    const ranks = severityFilter.map((s) => SEVERITY_RANK[s] ?? 0);
+    const minRank = Math.min(...ranks);
+    filtered = filtered.filter(
+      (a) => (SEVERITY_RANK[a.severity] ?? 0) >= minRank
+    );
+  }
+
+  if (cveFilter) {
+    filtered = filtered.filter(
+      (a) => a.cve?.toUpperCase() === cveFilter
+    );
+  }
+
+  if (streamFilter) {
+    filtered = filtered.filter(
+      (a) => a.stream.toLowerCase() === streamFilter
+    );
+  }
+
+  // Sort: highest severity first, then newest
+  filtered.sort((a, b) => {
+    const rankDiff =
+      (SEVERITY_RANK[b.severity] ?? 0) - (SEVERITY_RANK[a.severity] ?? 0);
+    if (rankDiff !== 0) return rankDiff;
+    return new Date(b.published).getTime() - new Date(a.published).getTime();
+  });
+
+  const advisories = filtered.slice(0, limit);
+
+  return {
+    count: advisories.length,
+    fetchedAt: new Date().toISOString(),
+    source: feedUrl,
+    advisories,
+    filters: {
+      ...(severityFilter ? { severity: severityFilter } : {}),
+      ...(cveFilter ? { cve: cveFilter } : {}),
+      ...(streamFilter ? { stream: streamFilter } : {}),
+      limit,
+    },
+  };
+}
+
+// ─── Tool executor integration ────────────────────────────────────────────────
+
+/**
+ * Lyrie tool definition for `threat_feed`.
+ * Register this with ToolExecutor.register() to expose it as an agent tool.
+ */
+export const threatFeedTool = {
+  name: "threat_feed",
+  description:
+    "Fetch real-time threat intelligence advisories from the Lyrie AI research newsroom (research.lyrie.ai). " +
+    "Filters by severity (CRITICAL/HIGH/MEDIUM/LOW), CVE ID, and stream (cve-deepdive, active-exploitation, etc.). " +
+    "Returns CVE, CVSS score, headline, summary, affected products, and Lyrie Shield verdict.",
+  parameters: {
+    severity: {
+      type: "string" as const,
+      description:
+        'Minimum severity filter. Options: CRITICAL, HIGH, MEDIUM, LOW, INFO. ' +
+        'Default: all severities. Pass "CRITICAL" to see only critical advisories.',
+      required: false,
+      enum: ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"],
+    },
+    cve: {
+      type: "string" as const,
+      description: "Filter by exact CVE ID, e.g. CVE-2025-12345.",
+      required: false,
+    },
+    stream: {
+      type: "string" as const,
+      description:
+        "Filter by research stream/category: cve-deepdive, active-exploitation, " +
+        "zero-day, patch-tuesday, ransomware, supply-chain, nation-state, threat-intel.",
+      required: false,
+    },
+    limit: {
+      type: "number" as const,
+      description: "Maximum number of advisories to return (default: 20, max: 100).",
+      required: false,
+      default: 20,
+    },
+  },
+  risk: "safe" as const,
+  untrustedOutput: true,
+  execute: async (args: Record<string, any>) => {
+    try {
+      const result = await fetchThreatFeed({
+        severity: args.severity as ThreatSeverity | undefined,
+        cve: args.cve as string | undefined,
+        stream: args.stream as string | undefined,
+        limit: Math.min(Number(args.limit) || DEFAULT_LIMIT, 100),
+      });
+
+      return {
+        success: true,
+        output: JSON.stringify(result, null, 2),
+        metadata: { count: result.count, source: result.source },
+      };
+    } catch (err: any) {
+      return {
+        success: false,
+        output: "",
+        error: err?.message ?? String(err),
+      };
+    }
+  },
+};


### PR DESCRIPTION
## v0.8.0 Release PR

### What's in this PR

#### 🌊 Feature 1: DeepSeek V4 Provider Bundle
- Added `packages/core/src/engine/providers/deepseek.ts`
- `DeepSeekProvider` class — OpenAI-compatible, targets `https://api.deepseek.com`
- Models: `deepseek-v4-pro` (1.6T params, 1M context) + `deepseek-v4-flash`
- Thinking mode support (`enable_thinking: true`)
- Auth: `DEEPSEEK_API_KEY` env var
- Exported from provider registry index with full TypeScript types

#### 📡 Feature 2: Live Threat Feed Integration
- Added `packages/core/src/tools/threat-feed.ts`
- `lyrie threat-feed` tool — fetches from `https://research.lyrie.ai/api/feed.json`
- Filters: severity (CRITICAL/HIGH/MEDIUM/LOW), CVE ID, stream category
- Output: structured JSON with CVE, CVSS, headline, summary, lyrie_verdict
- Shield-aware: `untrustedOutput: true` — scanned before reaching the model
- ToolExecutor-compatible: `threatFeedTool` export for direct registration

#### 🔍 Feature 3: README Complete Overhaul
- Fixed ALL CI/CodeQL/Releases badge URLs → `OTT-Cybersecurity-LLC/lyrie-ai`
- Added LinkedIn badge → `linkedin.com/company/lyrie-ai`
- Version highlights updated: v0.6.0 → v0.8.0
- Added "What's New in v0.8.0" section (DeepSeek V4, threat feed, SARIF, org, LinkedIn)
- Added DeepSeek V4 Pro row to LyrieAAV vs Audn.AI comparison table
- Updated clone URL + GitHub Action reference to new org
- Added LinkedIn to ecosystem table and footer
- Zero stale `overthetopseo` references remain

#### 📋 Feature 4: CHANGELOG v0.8.0 Entry
- Added `[0.8.0] — 2026-05-01` section at top of CHANGELOG.md
- Covers: DeepSeek bundle, threat-feed, SARIF viewer, LinkedIn, org migration, badge fixes

### Commits
- `feat: add DeepSeek V4 Pro + Flash provider bundle`
- `feat: add lyrie threat-feed tool — live threat intel from research.lyrie.ai`
- `docs: overhaul README for v0.8.0 and OTT-Cybersecurity-LLC org migration`
- `chore: add CHANGELOG entry for v0.8.0`

### Checklist
- [x] TypeScript compiles (providers follow existing pattern)
- [x] All stale badge/URL references fixed
- [x] No breaking changes to existing tools or providers
- [x] Shield Doctrine respected (untrustedOutput on threat feed)