### PR TITLE
feat(atp): Agent Trust Protocol v1.0 — reference implementation

### DIFF
--- a/packages/atp/README.md
+++ b/packages/atp/README.md
@@ -1,0 +1,580 @@
+# Agent Trust Protocol (ATP) v1.0
+
+```
+Internet Engineering Task Force                            G. Sheetrit, Ed.
+Independent Submission                                              Lyrie
+Intended status: Standards Track                                  May 2026
+Expires: November 2026
+```
+
+## Abstract
+
+The Agent Trust Protocol (ATP) defines a cryptographic standard for AI
+agent identity, authorisation scope, action attribution, and runtime
+state attestation. ATP gives operators, auditors, and peer systems the
+ability to answer four questions about any AI agent action with
+cryptographic certainty: **who took it**, **were they authorised**,
+**what exactly did they do**, and **has the agent itself been tampered
+with since deployment**.
+
+ATP is to AI agents what TLS is to web sessions and what x.509 is to web
+servers: a small, mandatory, deterministic substrate that every higher
+layer of the AI ecosystem can build trust on. This document describes
+ATP version 1.0 as a complete wire-format specification suitable for
+multiple independent implementations.
+
+## Status of This Memo
+
+This document is a working draft. It is intended to be submitted to the
+Internet Engineering Task Force (IETF) for consideration as a Standards
+Track RFC. Distribution is unlimited.
+
+The reference implementation accompanying this specification is
+`@lyrie/atp` (TypeScript, MIT-licensed, Ed25519 via Node built-ins). It
+is interoperable with any conformant implementation.
+
+Comments are solicited and should be addressed to the Lyrie engineering
+list (`dev@lyrie.ai`) or filed against the public issue tracker.
+
+## Copyright Notice
+
+Copyright (c) 2026 OTT Cybersecurity LLC. All rights reserved.
+
+This document is subject to the BSD-style license described in the
+LICENSE file of the repository accompanying this specification.
+
+---
+
+## 1. Introduction
+
+### 1.1 Motivation
+
+Throughout 2025–2026, autonomous AI agents transitioned from research
+artifacts to production infrastructure. With that shift came a class of
+incidents — MCP RCE family (CVE-2026-30615 et al.), unbounded sub-agent
+privilege escalation, prompt-injection hijacks, and silent tool-poisoning
+attacks — that revealed a structural absence: **AI agents had no
+cryptographic identity, no authenticated scope, and no attributable
+action log**.
+
+Existing standards do not fill this gap.
+
+* TLS authenticates **services**, not agents.
+* JWT authenticates **users**, not the AI acting on their behalf.
+* x.509 authenticates **machines**, not the model running on them.
+* OAuth scopes apply to **API clients**, not to autonomous reasoners
+  whose tool list is dynamic.
+
+ATP fills the gap. It provides:
+
+* **Agent Identity Certificates (AICs)** — self-signed Ed25519 passports
+  that bind one agent instance to one model, one system prompt, one
+  scope, and one operator.
+* **Action Receipts** — tamper-evident records that an agent took an
+  action under a specific AIC, optionally counter-signed by the receiver.
+* **Scope Declaration Language (SDL)** — a JSON dialect describing what
+  an agent may do, with composition rules that prevent privilege
+  escalation between parent and sub-agent.
+* **Trust Chains** — verifiable lineage from a root operator-issued AIC
+  down to any sub-agent, with the cryptographically enforced invariant
+  that scope only narrows.
+* **Breach Attestations** — periodic signed snapshots of agent state
+  that detect post-deployment tampering of system prompt, memory, or
+  tool history.
+
+### 1.2 Design Goals
+
+1. **Determinism.** Every artifact has exactly one canonical encoding;
+   two correct implementations must produce byte-identical signed forms.
+2. **Cross-language portability.** No PEM, no ASN.1 in the wire format,
+   no language-specific JSON quirks. JSON + base64-standard encoding +
+   Ed25519 raw 32-byte keys.
+3. **Zero external dependencies in the reference implementation.**
+   Implementable on any platform with SHA-256 + Ed25519 + JSON.
+4. **Composability.** Every primitive is independently verifiable and
+   the cross-primitive verifier is a thin dispatcher, not a god-object.
+5. **Forward compatibility.** Verification error codes are stable; new
+   codes are non-breaking; new fields are required to be ignored by
+   implementations that do not understand them.
+
+### 1.3 Non-Goals
+
+ATP intentionally does not specify:
+
+* **Key storage.** Operators store private keys however they wish (HSM,
+  KMS, file). ATP is key-storage-agnostic.
+* **Revocation distribution.** This document defines a revocation
+  *interface* (`isRevoked: CertId → boolean`) but not a revocation
+  protocol. CRL and OCSP-style mechanisms may be specified in a
+  companion document.
+* **Memory canonicalisation.** Breach Attestations consume hex SHA-256
+  digests of memory and tool-call history; the inputs producing those
+  digests are application-defined.
+* **Model authenticity.** A `modelHash` field exists for local/open-weight
+  deployments, but ATP does not specify how to obtain or verify it.
+
+---
+
+## 2. Terminology
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL
+NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**, and
+**OPTIONAL** in this document are to be interpreted as described in
+RFC 2119.
+
+* **Agent.** A software entity executing autonomous reasoning, typically
+  driven by a large language model, that may invoke tools, spawn
+  sub-agents, or take consequential external actions.
+* **Operator.** A human or organisational principal accountable for an
+  agent's actions. Identified by `operatorId` in an AIC.
+* **AIC.** Agent Identity Certificate. The Ed25519 self-signed
+  passport described in §3.1.
+* **CertId.** The lower-case hex SHA-256 of the canonical signed form
+  of an AIC.
+* **SDL.** Scope Declaration Language. The JSON-encoded authorisation
+  policy embedded in every AIC.
+* **Trust Chain.** An ordered list of AICs `[root, ..., leaf]` in which
+  each child is bound to its parent and operates within a subset of the
+  parent's scope.
+* **Receipt.** Action Receipt. A signed record of one agent action.
+* **Attestation.** Breach Attestation. A signed snapshot of agent
+  runtime state.
+
+---
+
+## 3. Protocol Primitives
+
+This section is normative. All five primitives are JSON objects with the
+field `version` set to the string `"1.0"` for this specification.
+
+Canonical JSON encoding (§3.0) MUST be used wherever a SHA-256 digest or
+Ed25519 signature is computed over a structured payload.
+
+### 3.0 Canonical JSON Encoding
+
+Implementations MUST produce a single canonical byte sequence per
+artifact when computing CertIds, signatures, and attestation hashes.
+The canonicalisation algorithm is a strict subset of RFC 8785 (JSON
+Canonicalization Scheme):
+
+1. Object keys are sorted lexicographically (UTF-16 code-unit order).
+2. No insignificant whitespace is emitted.
+3. Fields whose value is `undefined` (or missing) MUST NOT appear.
+4. `NaN`, `Infinity`, `-Infinity`, `BigInt`, function, and symbol values
+   MUST be rejected.
+5. ATP timestamps are integers (Unix milliseconds). Implementations MUST
+   reject floating-point timestamps; this guarantees deterministic
+   number serialisation independent of the host's float-formatting.
+
+### 3.1 Agent Identity Certificate (AIC)
+
+```jsonc
+{
+  "version": "1.0",
+  "agentId": "uuid-v4",
+  "modelId": "anthropic/claude-sonnet-4-6",
+  "modelHash": "sha256-hex-of-weights-or-omitted",
+  "systemPromptHash": "sha256-hex-of-system-prompt",
+  "scope": { /* ScopeDeclaration, see §3.3 */ },
+  "operatorId": "guy@lyrie.ai",
+  "issuedAt": 1714704000000,
+  "expiresAt": 1714790400000,
+  "publicKey":  "<base64-standard 32 bytes>",
+  "signature":  "<base64-standard 64 bytes>",
+  "parentCertId": "sha256-hex-of-parent-or-omitted"
+}
+```
+
+The `signature` field covers the canonical JSON of every other field
+(itself excluded). Verification MUST fail if any field has been mutated
+after signing.
+
+The `publicKey` and `privateKey` are raw Ed25519 keys, base64-standard
+encoded (32 raw bytes → 44 base64 characters; 64-byte signatures → 88
+characters). PEM encoding is **NOT** used in the wire format.
+
+The `CertId` of an AIC is the lower-case hex SHA-256 of its canonical
+signed form. Two equivalent AICs MUST yield equal CertIds.
+
+#### 3.1.1 Validity
+
+An AIC is valid at time `t` (Unix ms) if and only if:
+
+* `cert.signature` verifies against `cert.publicKey` over the canonical
+  unsigned form, AND
+* `cert.issuedAt ≤ t ≤ cert.expiresAt`, AND
+* the embedded scope structurally validates (§3.3.2), AND
+* the implementation's revocation oracle returns `false` for `CertId`.
+
+#### 3.1.2 Operator Linkage
+
+The `operatorId` field is an opaque string that names a human or
+organisational principal accountable for the agent. It MUST be present.
+ATP does not require operators to also hold ATP keys; in deployments
+where they do, the operator identity may be cryptographically anchored
+through a companion specification.
+
+### 3.2 Action Receipt
+
+```jsonc
+{
+  "version": "1.0",
+  "receiptId": "uuid-v4",
+  "agentCertId": "sha256-hex of issuing AIC",
+  "action": {
+    "tool":       "send_email",
+    "params":     { "to_hash": "sha256:...", "subject": "..." },
+    "timestamp":  1714704001000
+  },
+  "result": {
+    "success":    true,
+    "summary":    "Sent (non-sensitive description)",
+    "timestamp":  1714704001500
+  },
+  "agentSignature":     "<base64-standard 64 bytes>",
+  "receiverSignature":  "<base64-standard 64 bytes; OPTIONAL>",
+  "receiverPublicKey":  "<base64-standard 32 bytes; required if receiverSignature present>"
+}
+```
+
+The agent signs the canonical JSON of `{ version, receiptId, agentCertId,
+action, result }`. The receiver, if present, signs the **same** canonical
+payload — so the agent and receiver signatures are independent and may
+be added in either order without invalidating each other.
+
+`action.params` MUST NOT contain plaintext secrets. Implementations
+SHOULD substitute `{ "to_hash": "sha256:..." }` for sensitive fields.
+
+`result.summary` MUST be safe to publish in audit logs. Implementations
+SHOULD strip personally identifiable or operationally sensitive content.
+
+### 3.3 Scope Declaration Language (SDL)
+
+```jsonc
+{
+  "version": "1.0",
+  "allowedTools":       ["read_file", "send_email"],
+  "deniedTools":        ["shell_exec"],
+  "allowedDomains":     ["*.x.com", "lyrie.ai"],
+  "maxSubAgentDepth":   1,
+  "requireApprovalFor": ["send_email"],
+  "temporalScope": {
+    "validFrom":    1714704000000,
+    "validUntil":   1714790400000,
+    "allowedHours": [9,10,11,12,13,14,15,16,17]
+  },
+  "dataScope": {
+    "allowedLabels": ["public", "internal"],
+    "deniedLabels":  ["secret", "pii"]
+  }
+}
+```
+
+#### 3.3.1 Subset Rule (Normative)
+
+A scope `child` is a **subset** of `parent` if and only if all of:
+
+1. For every `t ∈ child.allowedTools`:
+   `t ∉ parent.deniedTools` AND (`t ∈ parent.allowedTools` OR
+   `"*" ∈ parent.allowedTools`).
+2. `child.deniedTools ⊇ parent.deniedTools`.
+3. If `parent.allowedDomains` is set, `child.allowedDomains` MUST be set
+   and every entry MUST be covered by a parent entry under the glob
+   semantics of §3.3.3.
+4. `child.maxSubAgentDepth ≤ parent.maxSubAgentDepth`.
+5. `child.requireApprovalFor ⊇ parent.requireApprovalFor`.
+6. The temporal window of `child` is contained in that of `parent`.
+7. `child.dataScope.allowedLabels ⊆ parent.dataScope.allowedLabels`.
+8. `child.dataScope.deniedLabels ⊇ parent.dataScope.deniedLabels`.
+
+This rule is the cryptographic primitive that prevents sub-agent
+privilege escalation: a Trust Chain whose any hop violates it MUST be
+rejected by every conformant verifier.
+
+#### 3.3.2 Validation
+
+`maxSubAgentDepth` MUST be a non-negative integer. `temporalScope.allowedHours`
+entries MUST be integers in 0–23. `temporalScope.validFrom ≤ validUntil`
+when both are present. All array fields MUST contain only strings.
+
+#### 3.3.3 Domain Glob Semantics
+
+Domain patterns MAY be exact (`api.x.com`), single-wildcard subdomain
+(`*.x.com` matches `a.x.com` and `a.b.x.com` but NOT `x.com`), or
+universal (`*` matches anything). No other glob constructs are permitted
+in v1.0.
+
+### 3.4 Trust Chain Rules
+
+A Trust Chain is the wire structure:
+
+```jsonc
+{
+  "rootCertId": "sha256-hex of chain[0]",
+  "chain": [ /* AIC, AIC, ..., AIC */ ],
+  "depth": 2
+}
+```
+
+A Trust Chain `C` is valid if and only if:
+
+1. `|C.chain| ≥ 1` and `|C.chain| - 1 == C.depth`.
+2. `CertId(C.chain[0]) == C.rootCertId`.
+3. `C.chain[0].parentCertId` is absent (the root MUST NOT chain upward).
+4. For every `i > 0`:
+   * `C.chain[i].parentCertId == CertId(C.chain[i-1])`,
+   * Each AIC individually verifies (§3.1.1) under the same temporal
+     evaluation point,
+   * `C.chain[i].scope` is a subset of `C.chain[i-1].scope` (§3.3.1),
+   * `C.chain[i-1].issuedAt ≤ C.chain[i].issuedAt ≤ C.chain[i-1].expiresAt`,
+   * `C.chain[i-1].scope.maxSubAgentDepth ≥ |C.chain| - i`.
+
+### 3.5 Breach Attestation
+
+```jsonc
+{
+  "version": "1.0",
+  "agentId": "uuid-v4",
+  "attestedAt": 1714704005000,
+  "stateHash": "sha256-hex(canonical({systemPromptHash, memoryHash, toolCallHistoryHash}))",
+  "previousHash": "sha256-hex of previous attestation (canonical signed form)",
+  "signature":   "<base64-standard 64 bytes>",
+  "attestorId":         "lyrie-verification-service",
+  "attestorSignature":  "<base64-standard 64 bytes; OPTIONAL>",
+  "attestorPublicKey":  "<base64-standard 32 bytes; required if attestorSignature present>"
+}
+```
+
+#### 3.5.1 State Hash
+
+`stateHash` is computed over the canonical JSON of the object
+`{ systemPromptHash, memoryHash, toolCallHistoryHash }`. The three
+inputs are themselves SHA-256 hex digests over application-defined
+canonical encodings of:
+
+* the agent's system prompt at attestation time,
+* the agent's memory store at attestation time,
+* the agent's complete ordered tool-call history.
+
+#### 3.5.2 Drift Detection
+
+A verifier given an `expectedStateHash` (derived independently from the
+verifier's view of the agent's state) MUST compare it against
+`attestation.stateHash`. Inequality indicates drift — either the
+attestation is stale, or the agent's state has been tampered with after
+the attestation was issued. Verifiers MUST surface this as the stable
+error code `ATP_ATTESTATION_DRIFT`.
+
+#### 3.5.3 Attestation Chains
+
+Successive attestations MAY form a hash chain via `previousHash`. When
+they do, every conformant chain verifier MUST reject:
+
+* a chain whose hop's `previousHash` does not equal
+  `sha256-hex(canonical(prev_attestation))`,
+* a chain whose `attestedAt` is not monotonically non-decreasing.
+
+---
+
+## 4. Security Considerations
+
+### 4.1 Threat Model
+
+ATP defends against:
+
+1. **Forged agent identity.** Without the AIC's private key, an attacker
+   cannot present a valid AIC for an agent they do not control.
+2. **Action repudiation.** A signed receipt is non-repudiable evidence
+   that the holder of the AIC's private key took the recorded action.
+3. **Sub-agent privilege escalation.** The Trust Chain subset rule
+   cryptographically prevents a child from claiming authority its
+   parent never held — the rule that, applied retrospectively, would
+   have prevented the MCP RCE family of 2026.
+4. **Post-deployment tampering of agent state.** Periodic Breach
+   Attestations whose state hash diverges from a verifier's
+   independently computed view detect prompt-injection persistence,
+   memory poisoning, and tool-history rewriting.
+
+### 4.2 Out of Scope
+
+ATP does **not** defend against:
+
+* **Compromise of the AIC private key.** This is equivalent to
+  compromise of the agent itself; revocation is the only remedy.
+* **Coerced legitimate actions.** A correctly-signed receipt for an
+  attacker-induced action is, by ATP's definitions, a valid receipt —
+  detection of such cases is upstream of ATP.
+* **Side-channel attribution.** ATP signs the action payload as
+  declared; if the agent's reasoning was hijacked by a prompt-injection
+  attack into producing that payload, ATP records the result faithfully
+  but does not by itself flag the cause.
+
+### 4.3 Cryptographic Choices
+
+Ed25519 is mandatory in v1.0. SHA-256 is mandatory for all hash inputs.
+A future ATP v1.1 MAY add post-quantum algorithms; v1.0 verifiers MUST
+reject artifacts using algorithms not specified here.
+
+### 4.4 Receipt Privacy
+
+`action.params` and `result.summary` MUST NOT carry plaintext secrets.
+Implementations are encouraged to substitute hashes or redacted
+descriptors. ATP does not encrypt receipts; if confidentiality of the
+audit log is required, transport-level encryption SHOULD be applied
+externally.
+
+### 4.5 Clock Skew
+
+All timestamp comparisons SHOULD apply implementation-configured skew
+tolerances. The reference implementation uses zero by default; deployers
+operating across federated trust boundaries SHOULD permit ±60 seconds.
+
+### 4.6 Replay Resistance
+
+Action Receipts include a `receiptId` (UUID v4) and timestamps. Ledger
+operators SHOULD detect replays by indexing on `(agentCertId, receiptId)`.
+
+---
+
+## 5. IANA Considerations
+
+This document requests IANA registration of the following items in a
+future "ATP Parameters" registry:
+
+* The protocol version string `"1.0"`.
+* The set of `VerificationErrorCode` values defined in §6 of the
+  reference implementation, including but not limited to:
+  `ATP_VERSION_MISMATCH`, `ATP_SIGNATURE_INVALID`,
+  `ATP_PUBLIC_KEY_INVALID`, `ATP_CERT_EXPIRED`,
+  `ATP_CERT_NOT_YET_VALID`, `ATP_CERT_REVOKED`, `ATP_SCOPE_INVALID`,
+  `ATP_SCOPE_WIDENING`, `ATP_CHAIN_BROKEN`,
+  `ATP_CHAIN_DEPTH_EXCEEDED`, `ATP_RECEIPT_AGENT_MISMATCH`,
+  `ATP_ATTESTATION_DRIFT`, `ATP_ATTESTATION_CHAIN_BROKEN`,
+  `ATP_TEMPORAL_OUT_OF_WINDOW`, `ATP_TOOL_NOT_ALLOWED`,
+  `ATP_DOMAIN_NOT_ALLOWED`, `ATP_MALFORMED`.
+
+A media type `application/atp+json` MAY be registered for ATP artifact
+exchange. This is not specified normatively in v1.0.
+
+---
+
+## 6. References
+
+### 6.1 Normative References
+
+* RFC 2119 — Key words for use in RFCs.
+* RFC 4648 — The Base16, Base32, and Base64 Data Encodings.
+* RFC 8032 — Edwards-Curve Digital Signature Algorithm (EdDSA).
+* RFC 8785 — JSON Canonicalization Scheme (JCS). The ATP canonical
+  encoding is a strict subset.
+* FIPS 180-4 — Secure Hash Standard (SHA-256).
+
+### 6.2 Informative References
+
+* OWASP — *Top 10 for LLM Applications, 2025/2026*.
+* Microsoft — *Agent Governance Toolkit, April 2026*.
+* CVE-2026-30615 — MCP RCE family (sub-agent privilege escalation).
+* Lyrie — *v1.0 Specification* and *Competitive Teardown* (Lyrie
+  Engineering, 2026).
+
+---
+
+## Appendix A: Worked Example
+
+A root operator-issued AIC, a sub-agent AIC, an Action Receipt, and a
+Breach Attestation follow. The example uses the reference implementation
+(`@lyrie/atp`) but every value is verifiable by any conformant
+implementation.
+
+```typescript
+import {
+  issueAic, signReceipt, attestState,
+  buildTrustChain, verifyTrustChain,
+  makeScope, sha256Hex,
+} from "@lyrie/atp";
+
+// 1. Operator issues a wide-scope root AIC.
+const rootScope = makeScope({
+  allowedTools: ["read_file", "send_email", "spawn_subagent"],
+  maxSubAgentDepth: 1,
+  requireApprovalFor: ["send_email"],
+});
+const root = issueAic({
+  modelId: "anthropic/claude-sonnet-4-6",
+  systemPromptHash: sha256Hex("You are an autonomous research agent."),
+  scope: rootScope,
+  operatorId: "guy@lyrie.ai",
+});
+
+// 2. The root spawns a narrowed sub-agent.
+const childScope = makeScope({
+  allowedTools: ["read_file"],         // strictly narrower
+  maxSubAgentDepth: 0,
+  requireApprovalFor: ["send_email"],  // inherits parent's approvals
+});
+const child = issueAic({
+  modelId: "anthropic/claude-sonnet-4-6",
+  systemPromptHash: sha256Hex("You are a read-only research worker."),
+  scope: childScope,
+  operatorId: "guy@lyrie.ai",
+  parentCertId: root.certId,
+});
+
+// 3. Build and verify the chain.
+const chain = buildTrustChain([root.cert, child.cert]);
+const result = verifyTrustChain(chain);  // { valid: true }
+
+// 4. The child performs an action and signs a receipt.
+const receipt = signReceipt({
+  cert: child.cert,
+  privateKey: child.keyPair.privateKey,
+  action: {
+    tool: "read_file",
+    params: { path: "/research/notes.md" },
+    timestamp: Date.now(),
+  },
+  result: {
+    success: true,
+    summary: "read 4096 bytes",
+    timestamp: Date.now(),
+  },
+});
+
+// 5. The child attests state for tamper detection.
+const attestation = attestState({
+  cert: child.cert,
+  privateKey: child.keyPair.privateKey,
+  state: {
+    systemPromptHash: child.cert.systemPromptHash,
+    memoryHash: sha256Hex("(memory snapshot bytes)"),
+    toolCallHistoryHash: sha256Hex("(tool history bytes)"),
+  },
+});
+```
+
+If, in step 2, `childScope` had set `allowedTools: ["read_file", "shell_exec"]`,
+the call to `verifyTrustChain` in step 3 would return
+`{ valid: false, code: "ATP_SCOPE_WIDENING" }` — the cryptographic rule
+that prevents sub-agent privilege escalation.
+
+## Appendix B: Compliance Levels
+
+ATP defines three compliance levels for use by implementers and auditors.
+
+| Level         | AIC | Receipts | SDL + Trust Chain | Breach Attestation |
+|---------------|:---:|:--------:|:-----------------:|:------------------:|
+| ATP-Basic     | ✓   | ✓        |                   |                    |
+| ATP-Standard  | ✓   | ✓        | ✓                 |                    |
+| ATP-Full      | ✓   | ✓        | ✓                 | ✓                  |
+
+Implementations MUST advertise their highest supported level. The
+reference implementation supports ATP-Full.
+
+The ATP Compliance Badge (`generateBadge`) emits a verifiable JSON
+payload alongside the SVG that contains the agent's AIC and most-recent
+attestation, allowing any consumer to re-verify the badge claims with
+the standard verifier.
+
+---
+
+*Author: Lyrie Engineering · OTT Cybersecurity LLC · `dev@lyrie.ai` · `https://lyrie.ai`*

--- a/packages/atp/package.json
+++ b/packages/atp/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@lyrie/atp",
+  "version": "1.0.0",
+  "description": "Agent Trust Protocol (ATP) — the cryptographic standard for AI agent identity, scope, and action verification. Reference implementation.",
+  "author": "OTT Cybersecurity LLC <dev@lyrie.ai> (https://lyrie.ai)",
+  "license": "MIT",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "bun test",
+    "build": "bun build src/index.ts --outdir dist --target node"
+  },
+  "keywords": [
+    "atp",
+    "agent-trust-protocol",
+    "ai-security",
+    "cryptography",
+    "ed25519",
+    "identity",
+    "agent-identity",
+    "lyrie"
+  ],
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/overthetopseo/lyrie-agent.git",
+    "directory": "packages/atp"
+  },
+  "homepage": "https://lyrie.ai/atp",
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/atp/src/aic.ts
+++ b/packages/atp/src/aic.ts
@@ -1,0 +1,210 @@
+/**
+ * aic.ts — Agent Identity Certificate.
+ *
+ * The AIC is the first ATP primitive: a self-signed Ed25519 certificate that
+ * binds an agent instance to:
+ *   - a model identity (and optional weight hash)
+ *   - a system-prompt hash
+ *   - an authorisation scope (SDL)
+ *   - an operator (human accountability anchor)
+ *   - a validity window
+ *   - optionally, a parent certificate (for sub-agents)
+ *
+ * Possession of the matching private key IS the agent. The certificate is
+ * cryptographically what the agent presents to any tool, peer, or audit log.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import {
+  canonicalize,
+  generateKeyPair,
+  isBase64Bytes,
+  newUuid,
+  sha256Hex,
+  signCanonical,
+  verifyCanonical,
+} from "./crypto";
+import type {
+  AgentIdentityCertificate,
+  AtpKeyPair,
+  CertId,
+  ScopeDeclaration,
+  VerificationResult,
+} from "./types";
+import { ATP_VERSION } from "./types";
+import { validateScope } from "./scope";
+
+// ─── Issuance ────────────────────────────────────────────────────────────────
+
+export interface IssueAicInput {
+  modelId: string;
+  modelHash?: string;
+  systemPromptHash: string;
+  scope: ScopeDeclaration;
+  operatorId: string;
+  /** Validity window length in ms. Default 24h. */
+  ttlMs?: number;
+  /** Override `issuedAt` (Unix ms) for testability. */
+  issuedAt?: number;
+  /** If present, this AIC is a sub-agent certificate. */
+  parentCertId?: CertId;
+  /** Pre-existing key pair (e.g. when the agent persists keys). Generated if absent. */
+  keyPair?: AtpKeyPair;
+  /** Pre-assigned agentId (UUID). Generated if absent. */
+  agentId?: string;
+}
+
+export interface IssueAicResult {
+  cert: AgentIdentityCertificate;
+  certId: CertId;
+  keyPair: AtpKeyPair;
+}
+
+/**
+ * Issue (self-sign) a new Agent Identity Certificate. Generates a fresh
+ * Ed25519 key pair unless one is provided. Returns the cert, its stable
+ * CertId (SHA-256 over canonical signed form), and the key pair.
+ *
+ * Caller is responsible for storing the private key securely. ATP itself
+ * is key-storage-agnostic.
+ */
+export function issueAic(input: IssueAicInput): IssueAicResult {
+  const scopeCheck = validateScope(input.scope);
+  if (!scopeCheck.valid) {
+    throw new Error(`ATP: cannot issue AIC with invalid scope: ${scopeCheck.reason}`);
+  }
+  const keyPair = input.keyPair ?? generateKeyPair();
+  const issuedAt = input.issuedAt ?? Date.now();
+  const ttl = input.ttlMs ?? 24 * 60 * 60 * 1000;
+
+  const unsigned: Omit<AgentIdentityCertificate, "signature"> = {
+    version: ATP_VERSION,
+    agentId: input.agentId ?? newUuid(),
+    modelId: input.modelId,
+    modelHash: input.modelHash,
+    systemPromptHash: input.systemPromptHash,
+    scope: input.scope,
+    operatorId: input.operatorId,
+    issuedAt,
+    expiresAt: issuedAt + ttl,
+    publicKey: keyPair.publicKey,
+    parentCertId: input.parentCertId,
+  };
+
+  const signature = signCanonical(unsigned, keyPair.privateKey);
+  const cert: AgentIdentityCertificate = { ...unsigned, signature };
+  return { cert, certId: certIdOf(cert), keyPair };
+}
+
+// ─── Identifier ──────────────────────────────────────────────────────────────
+
+/**
+ * Stable AIC identifier — SHA-256 (hex) over the canonical signed form.
+ * Two equal certs always produce the same CertId; any mutation changes it.
+ */
+export function certIdOf(cert: AgentIdentityCertificate): CertId {
+  return sha256Hex(canonicalize(cert));
+}
+
+// ─── Verification ────────────────────────────────────────────────────────────
+
+export interface VerifyAicOptions {
+  /** Wall-clock used for expiry checks. Default `Date.now()`. */
+  now?: number;
+  /** Optional revocation check — returns true to mark a CertId as revoked. */
+  isRevoked?: (certId: CertId) => boolean;
+  /** Skip the expiry check. Default false. */
+  ignoreExpiry?: boolean;
+}
+
+/**
+ * Verify an Agent Identity Certificate end-to-end:
+ *   1. Structural well-formedness (version, types, key/sig lengths).
+ *   2. Embedded scope validates.
+ *   3. Self-signature is valid.
+ *   4. Currently within validity window (unless `ignoreExpiry`).
+ *   5. Not in the revocation set, if one is provided.
+ */
+export function verifyAic(
+  cert: AgentIdentityCertificate,
+  opts: VerifyAicOptions = {},
+): VerificationResult {
+  if (!cert || typeof cert !== "object") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "cert must be object" };
+  }
+  if (cert.version !== ATP_VERSION) {
+    return { valid: false, code: "ATP_VERSION_MISMATCH", reason: `expected ${ATP_VERSION}` };
+  }
+  for (const k of ["agentId", "modelId", "systemPromptHash", "operatorId", "publicKey", "signature"] as const) {
+    if (typeof cert[k] !== "string" || cert[k].length === 0) {
+      return { valid: false, code: "ATP_MALFORMED", reason: `${k} must be non-empty string` };
+    }
+  }
+  if (typeof cert.issuedAt !== "number" || typeof cert.expiresAt !== "number") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "issuedAt / expiresAt must be numbers" };
+  }
+  if (cert.expiresAt <= cert.issuedAt) {
+    return { valid: false, code: "ATP_MALFORMED", reason: "expiresAt must be > issuedAt" };
+  }
+  if (!isBase64Bytes(cert.publicKey, 32)) {
+    return { valid: false, code: "ATP_PUBLIC_KEY_INVALID", reason: "publicKey not 32 raw bytes" };
+  }
+  if (!isBase64Bytes(cert.signature, 64)) {
+    return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "signature not 64 raw bytes" };
+  }
+
+  const scopeCheck = validateScope(cert.scope);
+  if (!scopeCheck.valid) return scopeCheck;
+
+  // Re-build the unsigned form and verify.
+  const { signature, ...unsigned } = cert;
+  if (!verifyCanonical(unsigned, cert.publicKey, signature)) {
+    return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "self-signature did not verify" };
+  }
+
+  if (!opts.ignoreExpiry) {
+    const now = opts.now ?? Date.now();
+    if (now < cert.issuedAt) {
+      return { valid: false, code: "ATP_CERT_NOT_YET_VALID", reason: `now (${now}) < issuedAt (${cert.issuedAt})` };
+    }
+    if (now > cert.expiresAt) {
+      return { valid: false, code: "ATP_CERT_EXPIRED", reason: `now (${now}) > expiresAt (${cert.expiresAt})` };
+    }
+  }
+
+  if (opts.isRevoked && opts.isRevoked(certIdOf(cert))) {
+    return { valid: false, code: "ATP_CERT_REVOKED", reason: "cert is revoked" };
+  }
+
+  return { valid: true };
+}
+
+// ─── Revocation registry (in-memory reference impl) ──────────────────────────
+
+/**
+ * RevocationRegistry — minimal in-memory revocation list.
+ *
+ * Production deployments will plug a persistent store (DB, distributed log)
+ * behind the same interface. The reference implementation is enough to
+ * exercise the verifier and to back unit tests.
+ */
+export class RevocationRegistry {
+  private readonly revoked = new Set<CertId>();
+
+  revoke(certId: CertId): void {
+    this.revoked.add(certId);
+  }
+
+  unrevoke(certId: CertId): void {
+    this.revoked.delete(certId);
+  }
+
+  isRevoked = (certId: CertId): boolean => {
+    return this.revoked.has(certId);
+  };
+
+  list(): CertId[] {
+    return Array.from(this.revoked);
+  }
+}

--- a/packages/atp/src/badge.ts
+++ b/packages/atp/src/badge.ts
@@ -1,0 +1,156 @@
+/**
+ * badge.ts — ATP Compliance Badge.
+ *
+ * Generates a human-visible SVG badge plus a machine-readable JSON
+ * attestation for an agent. Designed to be embedded in READMEs, dashboards,
+ * and agent metadata so anyone glancing at an agent can tell:
+ *
+ *   - what compliance level it claims (Basic / Standard / Full)
+ *   - where to verify it (a URL anchored on the cert hash)
+ *
+ * The badge is NOT cryptographic on its own — it's a UI surface. The
+ * `json` payload it ships alongside, however, is verifiable: it embeds the
+ * full AIC and the latest BreachAttestation. A consumer that fetches the
+ * badge JSON can run the standard `verifyArtifact` pipeline locally without
+ * trusting the badge issuer.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import type {
+  AgentIdentityCertificate,
+  BreachAttestation,
+  ComplianceLevel,
+} from "./types";
+import { certIdOf } from "./aic";
+
+export interface BadgeOptions {
+  /** Verification base URL (badge links to `${baseUrl}?cert=<hash>`). Default: lyrie.ai. */
+  verifyBaseUrl?: string;
+  /** Override the displayed compliance label. Auto-derived otherwise. */
+  level?: ComplianceLevel;
+  /** Short human-readable label shown on the badge (default: "ATP"). */
+  label?: string;
+}
+
+export interface BadgeOutput {
+  svg: string;
+  json: {
+    version: "1.0";
+    level: ComplianceLevel;
+    cert: AgentIdentityCertificate;
+    attestation: BreachAttestation;
+    certId: string;
+    verifyUrl: string;
+  };
+  verifyUrl: string;
+}
+
+/**
+ * Auto-derive compliance level from the artifacts a caller supplies.
+ *   - Has attestation? → ATP-Full
+ *   - Has cert with a non-empty scope? → ATP-Standard
+ *   - Else → ATP-Basic
+ */
+function deriveLevel(
+  cert: AgentIdentityCertificate,
+  attestation: BreachAttestation | undefined,
+): ComplianceLevel {
+  if (attestation) return "ATP-Full";
+  if (cert.scope && cert.scope.allowedTools.length > 0) return "ATP-Standard";
+  return "ATP-Basic";
+}
+
+/**
+ * Generate a verifiable ATP compliance badge for an agent.
+ */
+export function generateBadge(
+  cert: AgentIdentityCertificate,
+  attestation: BreachAttestation,
+  opts: BadgeOptions = {},
+): BadgeOutput {
+  const level = opts.level ?? deriveLevel(cert, attestation);
+  const baseUrl = opts.verifyBaseUrl ?? "https://lyrie.ai/verify";
+  const label = opts.label ?? "ATP";
+  const id = certIdOf(cert);
+  const verifyUrl = `${baseUrl}?cert=${id}`;
+
+  const color = badgeColor(level);
+  const status = level.replace("ATP-", "");
+  const svg = renderBadgeSvg({ label, status, color, verifyUrl });
+
+  return {
+    svg,
+    json: {
+      version: "1.0",
+      level,
+      cert,
+      attestation,
+      certId: id,
+      verifyUrl,
+    },
+    verifyUrl,
+  };
+}
+
+function badgeColor(level: ComplianceLevel): string {
+  switch (level) {
+    case "ATP-Full":
+      return "#2EA043"; // green
+    case "ATP-Standard":
+      return "#1F6FEB"; // blue
+    case "ATP-Basic":
+      return "#8B949E"; // grey
+  }
+}
+
+interface RenderInput {
+  label: string;
+  status: string;
+  color: string;
+  verifyUrl: string;
+}
+
+/**
+ * Render a 6.6em-tall shields-style badge as inline SVG.
+ *
+ * Implementation note: we deliberately produce ASCII-only output (no
+ * non-ASCII characters) and hard-code widths so the badge renders identically
+ * in any browser without depending on font metrics. Width approximation:
+ * label = 6 chars * 7px = 42, status = 7 chars * 7px = 49.
+ */
+function renderBadgeSvg(input: RenderInput): string {
+  const labelWidth = Math.max(40, input.label.length * 7 + 14);
+  const statusWidth = Math.max(50, input.status.length * 7 + 14);
+  const total = labelWidth + statusWidth;
+  const safeUrl = escapeXml(input.verifyUrl);
+  const safeLabel = escapeXml(input.label);
+  const safeStatus = escapeXml(input.status);
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="20" role="img" aria-label="${safeLabel}: ${safeStatus}">`,
+    `<title>${safeLabel}: ${safeStatus}</title>`,
+    `<linearGradient id="g" x2="0" y2="100%">`,
+    `<stop offset="0" stop-color="#fff" stop-opacity=".12"/>`,
+    `<stop offset="1" stop-opacity=".12"/>`,
+    `</linearGradient>`,
+    `<rect rx="3" width="${total}" height="20" fill="#555"/>`,
+    `<rect rx="3" x="${labelWidth}" width="${statusWidth}" height="20" fill="${input.color}"/>`,
+    `<rect rx="3" width="${total}" height="20" fill="url(#g)"/>`,
+    `<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">`,
+    `<text x="${labelWidth / 2}" y="14">${safeLabel}</text>`,
+    `<text x="${labelWidth + statusWidth / 2}" y="14">${safeStatus}</text>`,
+    `</g>`,
+    `<a href="${safeUrl}"><rect width="${total}" height="20" fill-opacity="0"/></a>`,
+    `</svg>`,
+  ].join("");
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/packages/atp/src/breach.ts
+++ b/packages/atp/src/breach.ts
@@ -1,0 +1,238 @@
+/**
+ * breach.ts — Breach Attestation.
+ *
+ * The fifth ATP primitive. A Breach Attestation is a periodic, signed
+ * snapshot of an agent's runtime state. Continuous attestation gives auditors
+ * a way to detect post-issuance tampering: if a hijacker mutates the agent's
+ * system prompt, memory, or tool-call history, the recomputed state hash
+ * will diverge from the last-attested value and verification will fail.
+ *
+ * Attestations form a hash chain (`previousHash`) so any inserted/removed
+ * attestation breaks the chain — analogous to a transparency log entry.
+ *
+ * The model says nothing about HOW to canonicalise memory and tool history
+ * — that is application-specific. ATP only requires SHA-256 hex inputs, so
+ * Lyrie (or any other implementer) chooses its own canonicalisation policy.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { canonicalize, isBase64Bytes, sha256Hex, signCanonical, verifyCanonical } from "./crypto";
+import type {
+  AgentIdentityCertificate,
+  AgentState,
+  BreachAttestation,
+  VerificationResult,
+} from "./types";
+import { ATP_VERSION } from "./types";
+
+// ─── State hashing ───────────────────────────────────────────────────────────
+
+/**
+ * Compute the canonical state hash that goes into the attestation. Inputs
+ * are joined deterministically; ordering is fixed by the AgentState type.
+ */
+export function hashAgentState(state: AgentState): string {
+  return sha256Hex(canonicalize({
+    systemPromptHash: state.systemPromptHash,
+    memoryHash: state.memoryHash,
+    toolCallHistoryHash: state.toolCallHistoryHash,
+  }));
+}
+
+// ─── Issue ───────────────────────────────────────────────────────────────────
+
+export interface AttestStateInput {
+  cert: AgentIdentityCertificate;
+  /** Agent's private key (base64). */
+  privateKey: string;
+  state: AgentState;
+  /** Hex SHA-256 of the previous attestation in the chain. */
+  previousHash?: string;
+  /** Override timestamp for testability. */
+  attestedAt?: number;
+}
+
+/**
+ * Generate and sign a fresh Breach Attestation.
+ */
+export function attestState(input: AttestStateInput): BreachAttestation {
+  const stateHash = hashAgentState(input.state);
+  const unsigned: Omit<BreachAttestation, "signature"> = {
+    version: ATP_VERSION,
+    agentId: input.cert.agentId,
+    attestedAt: input.attestedAt ?? Date.now(),
+    stateHash,
+    previousHash: input.previousHash,
+  };
+  const signature = signCanonical(attestationCorePayload(unsigned), input.privateKey);
+  return { ...unsigned, signature };
+}
+
+function attestationCorePayload(att: Omit<BreachAttestation, "signature"> | BreachAttestation) {
+  return {
+    version: att.version,
+    agentId: att.agentId,
+    attestedAt: att.attestedAt,
+    stateHash: att.stateHash,
+    previousHash: att.previousHash,
+  };
+}
+
+// ─── Attestor counter-sign ───────────────────────────────────────────────────
+
+/**
+ * Add a third-party attestor counter-signature (e.g. Lyrie verification
+ * service vouching for a hosted agent's state).
+ */
+export function addAttestorSignature(
+  attestation: BreachAttestation,
+  attestorId: string,
+  attestorPrivateKey: string,
+  attestorPublicKey: string,
+): BreachAttestation {
+  if (!isBase64Bytes(attestorPublicKey, 32)) {
+    throw new Error("ATP: attestorPublicKey must be 32 raw Ed25519 bytes (base64)");
+  }
+  const sig = signCanonical(attestationCorePayload(attestation), attestorPrivateKey);
+  return { ...attestation, attestorId, attestorSignature: sig, attestorPublicKey };
+}
+
+// ─── Verify ──────────────────────────────────────────────────────────────────
+
+export interface VerifyAttestationOptions {
+  /** AIC under which the agent signed this attestation. */
+  cert: AgentIdentityCertificate;
+  /**
+   * Expected state hash. If provided and it differs from the attestation's,
+   * we return ATP_ATTESTATION_DRIFT — indicating tampering or a stale
+   * attestation. If absent, signature is verified but drift is not.
+   */
+  expectedStateHash?: string;
+  /** Expected previousHash (audits the chain). */
+  expectedPreviousHash?: string;
+  /** Require an attestor counter-signature. */
+  requireAttestor?: boolean;
+}
+
+/**
+ * Verify a BreachAttestation:
+ *   1. structural well-formedness
+ *   2. agentId matches the supplied cert
+ *   3. agent signature is valid against the cert's public key
+ *   4. (optional) stateHash equals expectedStateHash
+ *   5. (optional) previousHash equals expectedPreviousHash
+ *   6. (optional) attestor signature verifies
+ */
+export function verifyAttestation(
+  att: BreachAttestation,
+  opts: VerifyAttestationOptions,
+): VerificationResult {
+  if (!att || typeof att !== "object") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "attestation must be object" };
+  }
+  if (att.version !== ATP_VERSION) {
+    return { valid: false, code: "ATP_VERSION_MISMATCH", reason: `expected ${ATP_VERSION}` };
+  }
+  if (att.agentId !== opts.cert.agentId) {
+    return {
+      valid: false,
+      code: "ATP_MALFORMED",
+      reason: `agentId ${att.agentId} != cert.agentId ${opts.cert.agentId}`,
+    };
+  }
+  if (typeof att.stateHash !== "string" || !/^[0-9a-f]{64}$/.test(att.stateHash)) {
+    return { valid: false, code: "ATP_MALFORMED", reason: "stateHash must be 64-char lowercase hex" };
+  }
+  if (typeof att.attestedAt !== "number") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "attestedAt must be number" };
+  }
+  if (!isBase64Bytes(att.signature, 64)) {
+    return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "signature not 64 bytes" };
+  }
+
+  if (!verifyCanonical(attestationCorePayload(att), opts.cert.publicKey, att.signature)) {
+    return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "agent signature did not verify" };
+  }
+
+  if (opts.expectedStateHash !== undefined && opts.expectedStateHash !== att.stateHash) {
+    return {
+      valid: false,
+      code: "ATP_ATTESTATION_DRIFT",
+      reason: `state hash drift: expected ${opts.expectedStateHash}, got ${att.stateHash}`,
+    };
+  }
+  if (
+    opts.expectedPreviousHash !== undefined &&
+    opts.expectedPreviousHash !== (att.previousHash ?? "")
+  ) {
+    return {
+      valid: false,
+      code: "ATP_ATTESTATION_CHAIN_BROKEN",
+      reason: `previousHash mismatch`,
+    };
+  }
+
+  if (opts.requireAttestor || att.attestorSignature !== undefined) {
+    if (!att.attestorSignature || !att.attestorPublicKey) {
+      return {
+        valid: false,
+        code: "ATP_SIGNATURE_INVALID",
+        reason: "attestor signature required but missing",
+      };
+    }
+    if (!isBase64Bytes(att.attestorPublicKey, 32) || !isBase64Bytes(att.attestorSignature, 64)) {
+      return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "malformed attestor key/sig" };
+    }
+    if (
+      !verifyCanonical(attestationCorePayload(att), att.attestorPublicKey, att.attestorSignature)
+    ) {
+      return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "attestor signature did not verify" };
+    }
+  }
+
+  return { valid: true };
+}
+
+// ─── Chain helpers ───────────────────────────────────────────────────────────
+
+/** Hex SHA-256 of an attestation's canonical signed form — the value the next attestation should put in `previousHash`. */
+export function attestationHash(att: BreachAttestation): string {
+  return sha256Hex(canonicalize(att));
+}
+
+/**
+ * Verify a temporally-ordered list of attestations from the same agent.
+ * Each attestation must reference the previous one's hash via `previousHash`,
+ * and `attestedAt` must be non-decreasing.
+ */
+export function verifyAttestationChain(
+  chain: BreachAttestation[],
+  cert: AgentIdentityCertificate,
+): VerificationResult {
+  if (chain.length === 0) {
+    return { valid: false, code: "ATP_MALFORMED", reason: "empty attestation chain" };
+  }
+  let prevHash: string | undefined;
+  let prevTime = -Infinity;
+  for (let i = 0; i < chain.length; i++) {
+    const att = chain[i]!;
+    const single = verifyAttestation(att, {
+      cert,
+      expectedPreviousHash: prevHash,
+    });
+    if (!single.valid) {
+      return { ...single, details: [{ code: single.code!, reason: single.reason!, index: i }] };
+    }
+    if (att.attestedAt < prevTime) {
+      return {
+        valid: false,
+        code: "ATP_ATTESTATION_CHAIN_BROKEN",
+        reason: `attestation[${i}].attestedAt went backwards`,
+      };
+    }
+    prevTime = att.attestedAt;
+    prevHash = attestationHash(att);
+  }
+  return { valid: true };
+}

--- a/packages/atp/src/crypto.ts
+++ b/packages/atp/src/crypto.ts
@@ -1,0 +1,175 @@
+/**
+ * crypto.ts — Internal helpers for ATP crypto + canonical encoding.
+ *
+ * Why a private module?
+ *   The ATP wire format is a contract; implementation choices (Ed25519 via
+ *   Node's built-in `crypto.sign`, JCS-style canonical JSON, raw 32-byte key
+ *   exchange) are not. Centralising them here means callers never reach for
+ *   `node:crypto` directly and we can swap libsodium / WebCrypto later
+ *   without churning every primitive file.
+ *
+ * No external dependencies — everything in this file uses Node 20+ built-ins.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  randomUUID,
+  sign as nodeSign,
+  verify as nodeVerify,
+} from "node:crypto";
+
+import type { AtpKeyPair } from "./types";
+
+// ─── UUIDs ───────────────────────────────────────────────────────────────────
+
+/** Stable wrapper so call-sites don't import node:crypto directly. */
+export function newUuid(): string {
+  return randomUUID();
+}
+
+// ─── Hashing ─────────────────────────────────────────────────────────────────
+
+/** SHA-256 of a UTF-8 string, hex-encoded (lowercase). */
+export function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+/** SHA-256 of raw bytes, hex-encoded. */
+export function sha256BytesHex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+// ─── Canonical JSON (subset of RFC 8785 / JCS) ───────────────────────────────
+
+/**
+ * Canonicalise a JSON-compatible value:
+ *   - object keys sorted lexicographically (UTF-16 code-unit order, like JS sort)
+ *   - no insignificant whitespace
+ *   - undefined values dropped
+ *   - functions / symbols rejected
+ *
+ * Numbers are serialised via `JSON.stringify`. ATP timestamps are integers,
+ * which JSON.stringify renders deterministically; we forbid floats in the
+ * wire format precisely so we never depend on float canonicalisation.
+ */
+export function canonicalize(value: unknown): string {
+  return JSON.stringify(stableClone(value));
+}
+
+function stableClone(v: unknown): unknown {
+  if (v === null) return null;
+  if (typeof v === "undefined") return undefined;
+  if (typeof v === "function" || typeof v === "symbol" || typeof v === "bigint") {
+    throw new TypeError(`ATP canonical JSON cannot encode ${typeof v}`);
+  }
+  if (Array.isArray(v)) return v.map(stableClone);
+  if (typeof v === "object") {
+    const out: Record<string, unknown> = {};
+    const keys = Object.keys(v as Record<string, unknown>).sort();
+    for (const k of keys) {
+      const child = stableClone((v as Record<string, unknown>)[k]);
+      if (typeof child === "undefined") continue;
+      out[k] = child;
+    }
+    return out;
+  }
+  return v;
+}
+
+// ─── Ed25519 keys ────────────────────────────────────────────────────────────
+
+/**
+ * Generate a fresh Ed25519 key pair. Both halves are exposed as raw 32-byte
+ * payloads, base64-standard encoded.
+ *
+ * Why raw + base64 (not PEM)?
+ *   Cross-language friendliness. Python (PyNaCl), Go (crypto/ed25519), Rust
+ *   (ed25519-dalek), and browser WebCrypto all speak raw 32-byte keys. PEM
+ *   adds a parser dependency for no benefit at our scale.
+ */
+export function generateKeyPair(): AtpKeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+
+  // Export to DER (SubjectPublicKeyInfo / PKCS#8) and slice the raw 32 bytes.
+  // Ed25519 SPKI = 12-byte ASN.1 prefix + 32 raw bytes.
+  // Ed25519 PKCS#8 = 16-byte prefix + 32 raw bytes.
+  const pubDer = publicKey.export({ format: "der", type: "spki" });
+  const privDer = privateKey.export({ format: "der", type: "pkcs8" });
+
+  const pubRaw = pubDer.subarray(pubDer.length - 32);
+  const privRaw = privDer.subarray(privDer.length - 32);
+
+  return {
+    publicKey: Buffer.from(pubRaw).toString("base64"),
+    privateKey: Buffer.from(privRaw).toString("base64"),
+  };
+}
+
+const ED25519_SPKI_PREFIX = Buffer.from([
+  0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+]);
+const ED25519_PKCS8_PREFIX = Buffer.from([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+]);
+
+function publicKeyObjectFromBase64(b64: string) {
+  const raw = Buffer.from(b64, "base64");
+  if (raw.length !== 32) throw new Error(`ATP: invalid Ed25519 public key length (${raw.length})`);
+  const der = Buffer.concat([ED25519_SPKI_PREFIX, raw]);
+  return createPublicKey({ key: der, format: "der", type: "spki" });
+}
+
+function privateKeyObjectFromBase64(b64: string) {
+  const raw = Buffer.from(b64, "base64");
+  if (raw.length !== 32) throw new Error(`ATP: invalid Ed25519 private key length (${raw.length})`);
+  const der = Buffer.concat([ED25519_PKCS8_PREFIX, raw]);
+  return createPrivateKey({ key: der, format: "der", type: "pkcs8" });
+}
+
+// ─── Sign / verify ───────────────────────────────────────────────────────────
+
+/**
+ * Sign the canonical JSON of `value` with `privateKey`.
+ * Returns base64-standard signature (64 raw bytes → 88 chars).
+ */
+export function signCanonical(value: unknown, privateKeyB64: string): string {
+  const message = Buffer.from(canonicalize(value), "utf8");
+  const key = privateKeyObjectFromBase64(privateKeyB64);
+  // Ed25519 in Node uses algorithm = null.
+  const sig = nodeSign(null, message, key);
+  return sig.toString("base64");
+}
+
+/**
+ * Verify an Ed25519 signature over the canonical JSON of `value`.
+ * Returns false on any decode error — never throws.
+ */
+export function verifyCanonical(
+  value: unknown,
+  publicKeyB64: string,
+  signatureB64: string,
+): boolean {
+  try {
+    const message = Buffer.from(canonicalize(value), "utf8");
+    const key = publicKeyObjectFromBase64(publicKeyB64);
+    const sig = Buffer.from(signatureB64, "base64");
+    if (sig.length !== 64) return false;
+    return nodeVerify(null, message, key, sig);
+  } catch {
+    return false;
+  }
+}
+
+/** True iff `b64` decodes to exactly `expected` bytes. */
+export function isBase64Bytes(b64: string, expected: number): boolean {
+  try {
+    return Buffer.from(b64, "base64").length === expected;
+  } catch {
+    return false;
+  }
+}

--- a/packages/atp/src/index.ts
+++ b/packages/atp/src/index.ts
@@ -1,0 +1,87 @@
+/**
+ * @lyrie/atp — Agent Trust Protocol v1.0 reference implementation.
+ *
+ * Public exports only. Submodules are internal — import from this entry
+ * point so future re-organisation does not break consumers.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+export type {
+  AgentIdentityCertificate,
+  ActionReceipt,
+  AgentState,
+  AtpKeyPair,
+  AtpVersion,
+  BreachAttestation,
+  CertId,
+  ComplianceLevel,
+  ScopeDeclaration,
+  TrustChain,
+  VerificationErrorCode,
+  VerificationResult,
+} from "./types";
+export { ATP_VERSION } from "./types";
+
+// ─── Crypto helpers (curated public surface) ─────────────────────────────────
+export { generateKeyPair, sha256Hex, sha256BytesHex, canonicalize } from "./crypto";
+
+// ─── AIC ─────────────────────────────────────────────────────────────────────
+export {
+  issueAic,
+  certIdOf,
+  verifyAic,
+  RevocationRegistry,
+} from "./aic";
+export type { IssueAicInput, IssueAicResult, VerifyAicOptions } from "./aic";
+
+// ─── Receipts ────────────────────────────────────────────────────────────────
+export {
+  signReceipt,
+  addReceiverSignature,
+  verifyReceipt,
+  receiptsForCert,
+} from "./receipt";
+export type { SignReceiptInput, VerifyReceiptOptions } from "./receipt";
+
+// ─── Scope (SDL) ─────────────────────────────────────────────────────────────
+export {
+  makeScope,
+  parseScope,
+  validateScope,
+  isScopeSubset,
+  mergeScopes,
+  domainCovers,
+  checkToolAllowed,
+  checkDomainAllowed,
+  checkTemporallyValid,
+} from "./scope";
+export type { ToolDecision } from "./scope";
+
+// ─── Trust Chain ─────────────────────────────────────────────────────────────
+export {
+  buildTrustChain,
+  verifyTrustChain,
+  verifyChainTerminatesAt,
+} from "./trust-chain";
+export type { VerifyTrustChainOptions } from "./trust-chain";
+
+// ─── Breach Attestation ──────────────────────────────────────────────────────
+export {
+  attestState,
+  addAttestorSignature,
+  verifyAttestation,
+  hashAgentState,
+  attestationHash,
+  verifyAttestationChain,
+} from "./breach";
+export type { AttestStateInput, VerifyAttestationOptions } from "./breach";
+
+// ─── Cross-primitive verification ────────────────────────────────────────────
+export { verifyArtifact, detectArtifactKind } from "./verify";
+export type { AtpArtifact, AtpVerifyContext } from "./verify";
+
+// ─── Badge ───────────────────────────────────────────────────────────────────
+export { generateBadge } from "./badge";
+export type { BadgeOptions, BadgeOutput } from "./badge";

--- a/packages/atp/src/receipt.ts
+++ b/packages/atp/src/receipt.ts
@@ -1,0 +1,186 @@
+/**
+ * receipt.ts — Action Receipts.
+ *
+ * The second ATP primitive. Every consequential action an agent takes
+ * (tool invocation, API call, file write, payment, message send) emits a
+ * signed receipt that:
+ *
+ *   - identifies the AIC under which the action was taken,
+ *   - records the action and its result with timestamps,
+ *   - is cryptographically tamper-evident.
+ *
+ * Receipts are append-only by convention. They form the audit substrate for
+ * "did agent X actually do Y?" — a question that, before ATP, no AI system
+ * could answer with cryptographic certainty.
+ *
+ * Optional receiver counter-signatures provide mutual non-repudiation when
+ * the receiving system also implements ATP (e.g. Lyrie talking to another
+ * Lyrie agent, or to an ATP-aware tool registry).
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import {
+  isBase64Bytes,
+  newUuid,
+  signCanonical,
+  verifyCanonical,
+} from "./crypto";
+import type {
+  ActionReceipt,
+  AgentIdentityCertificate,
+  CertId,
+  VerificationResult,
+} from "./types";
+import { ATP_VERSION } from "./types";
+import { certIdOf } from "./aic";
+
+// ─── Issue ───────────────────────────────────────────────────────────────────
+
+export interface SignReceiptInput {
+  /** AIC of the agent taking the action (used to bind agentCertId + verify caller holds the key). */
+  cert: AgentIdentityCertificate;
+  /** The agent's private key (base64). */
+  privateKey: string;
+  action: ActionReceipt["action"];
+  result: ActionReceipt["result"];
+  /** Optional pre-assigned receiptId. */
+  receiptId?: string;
+}
+
+/**
+ * Sign a fresh Action Receipt under `cert`. The signature covers the canonical
+ * JSON of every field except `agentSignature`, `receiverSignature`, and
+ * `receiverPublicKey` (counter-sigs are added later, see {@link addReceiverSignature}).
+ */
+export function signReceipt(input: SignReceiptInput): ActionReceipt {
+  const unsigned: Omit<ActionReceipt, "agentSignature"> = {
+    version: ATP_VERSION,
+    receiptId: input.receiptId ?? newUuid(),
+    agentCertId: certIdOf(input.cert),
+    action: input.action,
+    result: input.result,
+  };
+  const agentSignature = signCanonical(receiptCorePayload(unsigned), input.privateKey);
+  return { ...unsigned, agentSignature };
+}
+
+/**
+ * The bytes signed by the agent. We strip both signatures and the
+ * receiver-public-key from the canonical payload so receiver counter-signing
+ * does not invalidate the agent's signature, and vice versa.
+ */
+function receiptCorePayload(receipt: Omit<ActionReceipt, "agentSignature"> | ActionReceipt) {
+  const r = receipt as ActionReceipt;
+  return {
+    version: r.version,
+    receiptId: r.receiptId,
+    agentCertId: r.agentCertId,
+    action: r.action,
+    result: r.result,
+  };
+}
+
+// ─── Receiver counter-sign ───────────────────────────────────────────────────
+
+/**
+ * Add a receiver's counter-signature to an existing receipt. The receiver
+ * signs the same core payload as the agent (so signatures are independent
+ * but bound to identical content) and embeds its public key for verification.
+ */
+export function addReceiverSignature(
+  receipt: ActionReceipt,
+  receiverPrivateKey: string,
+  receiverPublicKey: string,
+): ActionReceipt {
+  if (!isBase64Bytes(receiverPublicKey, 32)) {
+    throw new Error("ATP: receiverPublicKey must be 32 raw Ed25519 bytes (base64)");
+  }
+  const sig = signCanonical(receiptCorePayload(receipt), receiverPrivateKey);
+  return { ...receipt, receiverSignature: sig, receiverPublicKey };
+}
+
+// ─── Verify ──────────────────────────────────────────────────────────────────
+
+export interface VerifyReceiptOptions {
+  /** AIC bound to this receipt; required for signature verification. */
+  cert: AgentIdentityCertificate;
+  /** If true, also verify the receiver's counter-signature (must be present). */
+  requireReceiverSignature?: boolean;
+}
+
+/**
+ * Verify an Action Receipt:
+ *   1. structural well-formedness
+ *   2. agentCertId matches the supplied cert's CertId
+ *   3. agent signature is valid against the cert's public key
+ *   4. (optional) receiver signature is valid against its embedded public key
+ */
+export function verifyReceipt(receipt: ActionReceipt, opts: VerifyReceiptOptions): VerificationResult {
+  if (!receipt || typeof receipt !== "object") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "receipt must be object" };
+  }
+  if (receipt.version !== ATP_VERSION) {
+    return { valid: false, code: "ATP_VERSION_MISMATCH", reason: `expected ${ATP_VERSION}` };
+  }
+  if (typeof receipt.receiptId !== "string" || !receipt.receiptId) {
+    return { valid: false, code: "ATP_MALFORMED", reason: "receiptId required" };
+  }
+  if (typeof receipt.agentCertId !== "string" || !receipt.agentCertId) {
+    return { valid: false, code: "ATP_MALFORMED", reason: "agentCertId required" };
+  }
+  if (!receipt.action || typeof receipt.action !== "object" || typeof receipt.action.tool !== "string") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "action.tool required" };
+  }
+  if (typeof receipt.action.timestamp !== "number" || typeof receipt.result?.timestamp !== "number") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "timestamps required" };
+  }
+  if (typeof receipt.result.success !== "boolean") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "result.success required" };
+  }
+  if (!isBase64Bytes(receipt.agentSignature, 64)) {
+    return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "agentSignature not 64 bytes" };
+  }
+
+  const expectedCertId = certIdOf(opts.cert);
+  if (receipt.agentCertId !== expectedCertId) {
+    return {
+      valid: false,
+      code: "ATP_RECEIPT_AGENT_MISMATCH",
+      reason: `agentCertId ${receipt.agentCertId} != cert ${expectedCertId}`,
+    };
+  }
+
+  const payload = receiptCorePayload(receipt);
+  if (!verifyCanonical(payload, opts.cert.publicKey, receipt.agentSignature)) {
+    return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "agent signature did not verify" };
+  }
+
+  if (opts.requireReceiverSignature || receipt.receiverSignature !== undefined) {
+    if (!receipt.receiverSignature || !receipt.receiverPublicKey) {
+      return {
+        valid: false,
+        code: "ATP_SIGNATURE_INVALID",
+        reason: "receiver signature required but missing",
+      };
+    }
+    if (!isBase64Bytes(receipt.receiverPublicKey, 32) || !isBase64Bytes(receipt.receiverSignature, 64)) {
+      return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "malformed receiver key/sig" };
+    }
+    if (!verifyCanonical(payload, receipt.receiverPublicKey, receipt.receiverSignature)) {
+      return { valid: false, code: "ATP_SIGNATURE_INVALID", reason: "receiver signature did not verify" };
+    }
+  }
+
+  return { valid: true };
+}
+
+// ─── Receipt log helpers ─────────────────────────────────────────────────────
+
+/**
+ * Filter a list of receipts to those issued by a specific AIC.
+ * Useful for audit queries: "what did agent X do during incident Y?"
+ */
+export function receiptsForCert(receipts: ActionReceipt[], certId: CertId): ActionReceipt[] {
+  return receipts.filter((r) => r.agentCertId === certId);
+}

--- a/packages/atp/src/scope.ts
+++ b/packages/atp/src/scope.ts
@@ -1,0 +1,370 @@
+/**
+ * scope.ts — Scope Declaration Language (SDL) operations.
+ *
+ * SDL is the third ATP primitive. It encodes what an agent may do, in a form
+ * that is:
+ *
+ *   - Declarative   (no procedural rules — pure data)
+ *   - Composable    (parent ⊇ child enforced by {@link mergeScopes})
+ *   - Cryptographically bindable (carried inside a signed AIC)
+ *
+ * The trust-chain invariant `child.scope ⊆ parent.scope` (subset, never
+ * widening) is the rule that prevents the agent equivalent of MCP RCE
+ * privilege escalation — a sub-agent cannot grant itself capabilities its
+ * parent never held.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import type { ScopeDeclaration, VerificationResult } from "./types";
+import { ATP_VERSION } from "./types";
+
+// ─── Construction & parsing ──────────────────────────────────────────────────
+
+/**
+ * Build a ScopeDeclaration with `version` filled in.
+ * Use this rather than literal objects so version bumps are typesafe.
+ */
+export function makeScope(input: Omit<ScopeDeclaration, "version">): ScopeDeclaration {
+  return { version: ATP_VERSION, ...input };
+}
+
+/**
+ * Parse a JSON string (or arbitrary unknown value) into a validated
+ * ScopeDeclaration. Throws on malformed input.
+ *
+ * Accepts JSON only — YAML support intentionally omitted from the reference
+ * implementation to keep the dependency surface zero. Operators are expected
+ * to pre-convert YAML at the orchestration layer.
+ */
+export function parseScope(input: string | unknown): ScopeDeclaration {
+  const obj = typeof input === "string" ? JSON.parse(input) : input;
+  const result = validateScope(obj);
+  if (!result.valid) {
+    throw new Error(`ATP: invalid scope (${result.code}): ${result.reason}`);
+  }
+  return obj as ScopeDeclaration;
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/** Structural validation. Does not check trust-chain relationships. */
+export function validateScope(value: unknown): VerificationResult {
+  if (!value || typeof value !== "object") {
+    return { valid: false, code: "ATP_MALFORMED", reason: "scope must be an object" };
+  }
+  const s = value as Record<string, unknown>;
+
+  if (s.version !== ATP_VERSION) {
+    return {
+      valid: false,
+      code: "ATP_VERSION_MISMATCH",
+      reason: `expected version ${ATP_VERSION}, got ${String(s.version)}`,
+    };
+  }
+  if (!Array.isArray(s.allowedTools) || !s.allowedTools.every((x) => typeof x === "string")) {
+    return { valid: false, code: "ATP_SCOPE_INVALID", reason: "allowedTools must be string[]" };
+  }
+  if (s.deniedTools !== undefined && !isStringArray(s.deniedTools)) {
+    return { valid: false, code: "ATP_SCOPE_INVALID", reason: "deniedTools must be string[]" };
+  }
+  if (s.allowedDomains !== undefined && !isStringArray(s.allowedDomains)) {
+    return { valid: false, code: "ATP_SCOPE_INVALID", reason: "allowedDomains must be string[]" };
+  }
+  if (typeof s.maxSubAgentDepth !== "number" || !Number.isInteger(s.maxSubAgentDepth) || s.maxSubAgentDepth < 0) {
+    return {
+      valid: false,
+      code: "ATP_SCOPE_INVALID",
+      reason: "maxSubAgentDepth must be a non-negative integer",
+    };
+  }
+  if (s.requireApprovalFor !== undefined && !isStringArray(s.requireApprovalFor)) {
+    return {
+      valid: false,
+      code: "ATP_SCOPE_INVALID",
+      reason: "requireApprovalFor must be string[]",
+    };
+  }
+  if (s.temporalScope !== undefined) {
+    const t = s.temporalScope as Record<string, unknown>;
+    if (t === null || typeof t !== "object") {
+      return { valid: false, code: "ATP_SCOPE_INVALID", reason: "temporalScope must be object" };
+    }
+    if (t.validFrom !== undefined && typeof t.validFrom !== "number") {
+      return { valid: false, code: "ATP_SCOPE_INVALID", reason: "temporalScope.validFrom must be number" };
+    }
+    if (t.validUntil !== undefined && typeof t.validUntil !== "number") {
+      return { valid: false, code: "ATP_SCOPE_INVALID", reason: "temporalScope.validUntil must be number" };
+    }
+    if (typeof t.validFrom === "number" && typeof t.validUntil === "number" && t.validFrom > t.validUntil) {
+      return {
+        valid: false,
+        code: "ATP_SCOPE_INVALID",
+        reason: "temporalScope.validFrom must be ≤ validUntil",
+      };
+    }
+    if (t.allowedHours !== undefined) {
+      if (!Array.isArray(t.allowedHours) || !t.allowedHours.every((h) => typeof h === "number" && h >= 0 && h <= 23 && Number.isInteger(h))) {
+        return {
+          valid: false,
+          code: "ATP_SCOPE_INVALID",
+          reason: "temporalScope.allowedHours must be integers 0–23",
+        };
+      }
+    }
+  }
+  if (s.dataScope !== undefined) {
+    const d = s.dataScope as Record<string, unknown>;
+    if (d === null || typeof d !== "object") {
+      return { valid: false, code: "ATP_SCOPE_INVALID", reason: "dataScope must be object" };
+    }
+    if (d.allowedLabels !== undefined && !isStringArray(d.allowedLabels)) {
+      return {
+        valid: false,
+        code: "ATP_SCOPE_INVALID",
+        reason: "dataScope.allowedLabels must be string[]",
+      };
+    }
+    if (d.deniedLabels !== undefined && !isStringArray(d.deniedLabels)) {
+      return {
+        valid: false,
+        code: "ATP_SCOPE_INVALID",
+        reason: "dataScope.deniedLabels must be string[]",
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+// ─── Subset / merge ──────────────────────────────────────────────────────────
+
+/**
+ * Returns true iff `child` is a subset of `parent`.
+ *
+ * Rules (applied in this order):
+ *   - every tool in child.allowedTools must be allowed by parent
+ *     (i.e. in parent.allowedTools AND not in parent.deniedTools)
+ *   - child.allowedDomains must be ⊆ parent.allowedDomains (when parent
+ *     specifies any). Glob entries match if the parent has either an
+ *     identical glob OR a broader one (`*.x.com` covers `a.x.com`).
+ *   - child.maxSubAgentDepth ≤ parent.maxSubAgentDepth
+ *   - child temporal window must be within parent's
+ *   - child requireApprovalFor must be a SUPERSET of parent's
+ *     (children may add approvals, never remove them)
+ *   - child dataScope.allowedLabels must be ⊆ parent's
+ *   - child dataScope.deniedLabels must be ⊇ parent's (more restrictive)
+ */
+export function isScopeSubset(child: ScopeDeclaration, parent: ScopeDeclaration): boolean {
+  // Tools
+  const parentDenied = new Set(parent.deniedTools ?? []);
+  const parentAllowed = new Set(parent.allowedTools);
+  for (const t of child.allowedTools) {
+    if (parentDenied.has(t)) return false;
+    if (!parentAllowed.has(t) && !parent.allowedTools.includes("*")) return false;
+  }
+  // Child's deny list must include every tool parent denies.
+  const childDenied = new Set(child.deniedTools ?? []);
+  for (const t of parentDenied) if (!childDenied.has(t)) return false;
+
+  // Domains
+  if (parent.allowedDomains !== undefined) {
+    if (child.allowedDomains === undefined) return false; // open-ended child > scoped parent
+    for (const d of child.allowedDomains) {
+      if (!parent.allowedDomains.some((p) => domainCovers(p, d))) return false;
+    }
+  }
+
+  // Depth
+  if (child.maxSubAgentDepth > parent.maxSubAgentDepth) return false;
+
+  // Approval list — child must require approvals for at least everything parent does
+  const childApproval = new Set(child.requireApprovalFor ?? []);
+  for (const t of parent.requireApprovalFor ?? []) if (!childApproval.has(t)) return false;
+
+  // Temporal window
+  if (parent.temporalScope) {
+    const pt = parent.temporalScope;
+    const ct = child.temporalScope ?? {};
+    if (pt.validFrom !== undefined) {
+      if (ct.validFrom === undefined || ct.validFrom < pt.validFrom) return false;
+    }
+    if (pt.validUntil !== undefined) {
+      if (ct.validUntil === undefined || ct.validUntil > pt.validUntil) return false;
+    }
+    if (pt.allowedHours && pt.allowedHours.length > 0) {
+      if (!ct.allowedHours || ct.allowedHours.some((h) => !pt.allowedHours!.includes(h))) {
+        return false;
+      }
+    }
+  }
+
+  // Data scope
+  if (parent.dataScope?.allowedLabels) {
+    if (!child.dataScope?.allowedLabels) return false;
+    for (const l of child.dataScope.allowedLabels) {
+      if (!parent.dataScope.allowedLabels.includes(l)) return false;
+    }
+  }
+  if (parent.dataScope?.deniedLabels) {
+    const childDeniedLabels = new Set(child.dataScope?.deniedLabels ?? []);
+    for (const l of parent.dataScope.deniedLabels) {
+      if (!childDeniedLabels.has(l)) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Glob-match: does `parent` cover `child`?
+ *
+ * Supports a single leading `*.` wildcard (matches any subdomain), exact
+ * match, and `*` for any. No regex parsing; one wildcard per pattern.
+ */
+export function domainCovers(parent: string, child: string): boolean {
+  if (parent === child) return true;
+  if (parent === "*") return true;
+  if (parent.startsWith("*.")) {
+    const suffix = parent.slice(1); // ".x.com"
+    return child.endsWith(suffix) && child.length > suffix.length;
+  }
+  return false;
+}
+
+/**
+ * Compute the *intersection* of parent and child scopes. Returns the most
+ * permissive scope that is still a subset of both. If parent and child are
+ * incompatible, the returned scope will never widen `parent` — but callers
+ * who want to enforce "child must already be a subset" should call
+ * {@link isScopeSubset} first.
+ *
+ * This is the function to call when an agent presents a desired sub-agent
+ * scope: pass the parent scope and the desired child, and use the result
+ * as the actual sub-agent scope.
+ */
+export function mergeScopes(parent: ScopeDeclaration, child: ScopeDeclaration): ScopeDeclaration {
+  const parentDenied = new Set(parent.deniedTools ?? []);
+  const allowedTools = child.allowedTools.filter(
+    (t) => !parentDenied.has(t) && (parent.allowedTools.includes(t) || parent.allowedTools.includes("*")),
+  );
+  const deniedTools = Array.from(new Set([...(parent.deniedTools ?? []), ...(child.deniedTools ?? [])]));
+
+  const merged: ScopeDeclaration = {
+    version: ATP_VERSION,
+    allowedTools,
+    deniedTools: deniedTools.length ? deniedTools : undefined,
+    maxSubAgentDepth: Math.min(parent.maxSubAgentDepth, child.maxSubAgentDepth),
+    requireApprovalFor: Array.from(
+      new Set([...(parent.requireApprovalFor ?? []), ...(child.requireApprovalFor ?? [])]),
+    ),
+  };
+
+  if (parent.allowedDomains !== undefined || child.allowedDomains !== undefined) {
+    if (parent.allowedDomains === undefined) {
+      merged.allowedDomains = child.allowedDomains ? [...child.allowedDomains] : undefined;
+    } else if (child.allowedDomains === undefined) {
+      merged.allowedDomains = [...parent.allowedDomains];
+    } else {
+      merged.allowedDomains = child.allowedDomains.filter((d) =>
+        parent.allowedDomains!.some((p) => domainCovers(p, d)),
+      );
+    }
+  }
+
+  // Temporal — intersect.
+  if (parent.temporalScope || child.temporalScope) {
+    const pt = parent.temporalScope ?? {};
+    const ct = child.temporalScope ?? {};
+    const validFrom = maxDefined(pt.validFrom, ct.validFrom);
+    const validUntil = minDefined(pt.validUntil, ct.validUntil);
+    let allowedHours: number[] | undefined;
+    if (pt.allowedHours && ct.allowedHours) {
+      allowedHours = ct.allowedHours.filter((h) => pt.allowedHours!.includes(h));
+    } else {
+      allowedHours = pt.allowedHours ?? ct.allowedHours;
+    }
+    merged.temporalScope = { validFrom, validUntil, allowedHours };
+  }
+
+  // Data scope — intersect allowed, union denied.
+  if (parent.dataScope || child.dataScope) {
+    const pa = parent.dataScope?.allowedLabels;
+    const ca = child.dataScope?.allowedLabels;
+    let allowedLabels: string[] | undefined;
+    if (pa && ca) allowedLabels = ca.filter((l) => pa.includes(l));
+    else if (pa) allowedLabels = [...pa];
+    else if (ca) allowedLabels = [...ca];
+    const deniedLabels = Array.from(
+      new Set([...(parent.dataScope?.deniedLabels ?? []), ...(child.dataScope?.deniedLabels ?? [])]),
+    );
+    merged.dataScope = {
+      allowedLabels,
+      deniedLabels: deniedLabels.length ? deniedLabels : undefined,
+    };
+  }
+
+  return merged;
+}
+
+function maxDefined(a?: number, b?: number): number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.max(a, b);
+}
+function minDefined(a?: number, b?: number): number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.min(a, b);
+}
+
+// ─── Decision helpers ────────────────────────────────────────────────────────
+
+export interface ToolDecision {
+  allowed: boolean;
+  requiresApproval: boolean;
+  reason?: string;
+}
+
+/**
+ * Decide whether a given tool invocation is permitted by a scope, ignoring
+ * domain/temporal context. Returns whether it's allowed AND whether the
+ * scope marks it as requiring human approval before execution.
+ */
+export function checkToolAllowed(tool: string, scope: ScopeDeclaration): ToolDecision {
+  if ((scope.deniedTools ?? []).includes(tool)) {
+    return { allowed: false, requiresApproval: false, reason: "denied" };
+  }
+  const wildcard = scope.allowedTools.includes("*");
+  if (!wildcard && !scope.allowedTools.includes(tool)) {
+    return { allowed: false, requiresApproval: false, reason: "not in allow-list" };
+  }
+  const requiresApproval = (scope.requireApprovalFor ?? []).includes(tool);
+  return { allowed: true, requiresApproval };
+}
+
+/** Check a domain against scope.allowedDomains, returning true if accessible. */
+export function checkDomainAllowed(domain: string, scope: ScopeDeclaration): boolean {
+  if (!scope.allowedDomains) return true;
+  return scope.allowedDomains.some((p) => domainCovers(p, domain));
+}
+
+/**
+ * Check whether a scope is currently "in window" given the wall-clock time.
+ * Pass `now` (Unix ms) for testability; defaults to `Date.now()`.
+ */
+export function checkTemporallyValid(scope: ScopeDeclaration, now: number = Date.now()): boolean {
+  const t = scope.temporalScope;
+  if (!t) return true;
+  if (t.validFrom !== undefined && now < t.validFrom) return false;
+  if (t.validUntil !== undefined && now > t.validUntil) return false;
+  if (t.allowedHours && t.allowedHours.length > 0) {
+    const hour = new Date(now).getUTCHours();
+    if (!t.allowedHours.includes(hour)) return false;
+  }
+  return true;
+}

--- a/packages/atp/src/trust-chain.ts
+++ b/packages/atp/src/trust-chain.ts
@@ -1,0 +1,190 @@
+/**
+ * trust-chain.ts — Trust Chain rules.
+ *
+ * The fourth ATP primitive. A TrustChain is the verified, ordered ancestry
+ * of AICs from a root operator-issued certificate down to a leaf sub-agent.
+ *
+ * The hard rule, enforced cryptographically: **every child's scope is a
+ * subset of its parent's**. A spawned agent cannot exceed the authority of
+ * the agent that spawned it. This is the rule that, had it existed in 2026,
+ * would have prevented the MCP RCE family of privilege-escalation
+ * vulnerabilities (CVE-2026-30615 et al.) — sub-agents and tool plugins
+ * could not have silently widened their own permissions.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import type {
+  AgentIdentityCertificate,
+  CertId,
+  TrustChain,
+  VerificationResult,
+} from "./types";
+import { certIdOf, verifyAic, type VerifyAicOptions } from "./aic";
+import { isScopeSubset } from "./scope";
+
+// ─── Construction ────────────────────────────────────────────────────────────
+
+/**
+ * Build a TrustChain from an ordered list `[root, ..., leaf]`. Performs
+ * structural setup only — call {@link verifyTrustChain} to enforce the
+ * cryptographic invariants.
+ */
+export function buildTrustChain(chain: AgentIdentityCertificate[]): TrustChain {
+  if (chain.length === 0) {
+    throw new Error("ATP: trust chain must have at least one cert (the root)");
+  }
+  return {
+    rootCertId: certIdOf(chain[0]!),
+    chain,
+    depth: chain.length - 1,
+  };
+}
+
+// ─── Verification ────────────────────────────────────────────────────────────
+
+export interface VerifyTrustChainOptions extends VerifyAicOptions {
+  /**
+   * Optional cap: reject chains deeper than this even if the parent's scope
+   * `maxSubAgentDepth` would allow it. Useful as a global safety brake.
+   */
+  maxDepth?: number;
+}
+
+/**
+ * Verify a TrustChain end-to-end:
+ *   1. each AIC verifies on its own (signature, scope, expiry, revocation)
+ *   2. parent/child links are correct (parentCertId chains to predecessor's CertId)
+ *   3. each child's scope ⊆ parent's scope
+ *   4. each child's `issuedAt` falls within its parent's validity window
+ *   5. each level descends within parent's `maxSubAgentDepth`
+ *   6. global maxDepth (if provided) is not exceeded
+ *
+ * Returns a `VerificationResult` with `details` populated when multiple
+ * link errors are present, so audit tools can show every broken hop.
+ */
+export function verifyTrustChain(
+  chain: TrustChain,
+  opts: VerifyTrustChainOptions = {},
+): VerificationResult {
+  if (!Array.isArray(chain.chain) || chain.chain.length === 0) {
+    return { valid: false, code: "ATP_CHAIN_BROKEN", reason: "empty chain" };
+  }
+  if (chain.chain.length - 1 !== chain.depth) {
+    return {
+      valid: false,
+      code: "ATP_CHAIN_BROKEN",
+      reason: `depth mismatch: chain has ${chain.chain.length} certs but depth=${chain.depth}`,
+    };
+  }
+  if (opts.maxDepth !== undefined && chain.depth > opts.maxDepth) {
+    return {
+      valid: false,
+      code: "ATP_CHAIN_DEPTH_EXCEEDED",
+      reason: `depth ${chain.depth} > maxDepth ${opts.maxDepth}`,
+    };
+  }
+  if (certIdOf(chain.chain[0]!) !== chain.rootCertId) {
+    return { valid: false, code: "ATP_CHAIN_BROKEN", reason: "rootCertId does not match chain[0]" };
+  }
+
+  const details: Array<{ code: VerificationResult["code"] & string; reason: string; index?: number }> = [];
+
+  for (let i = 0; i < chain.chain.length; i++) {
+    const cert = chain.chain[i]!;
+    const aic = verifyAic(cert, opts);
+    if (!aic.valid) {
+      details.push({ code: aic.code ?? "ATP_MALFORMED", reason: aic.reason ?? "invalid", index: i });
+      continue; // keep collecting, but skip relational checks for this hop
+    }
+
+    if (i === 0) {
+      // The root cert MUST NOT have a parent.
+      if (cert.parentCertId !== undefined) {
+        details.push({
+          code: "ATP_CHAIN_BROKEN",
+          reason: "root cert must not have a parentCertId",
+          index: 0,
+        });
+      }
+      continue;
+    }
+
+    const parent = chain.chain[i - 1]!;
+    const parentId = certIdOf(parent);
+
+    if (cert.parentCertId !== parentId) {
+      details.push({
+        code: "ATP_CHAIN_BROKEN",
+        reason: `chain[${i}].parentCertId (${cert.parentCertId}) != chain[${i - 1}] CertId (${parentId})`,
+        index: i,
+      });
+    }
+
+    // Scope subset
+    if (!isScopeSubset(cert.scope, parent.scope)) {
+      details.push({
+        code: "ATP_SCOPE_WIDENING",
+        reason: `chain[${i}] scope is not a subset of chain[${i - 1}] scope`,
+        index: i,
+      });
+    }
+
+    // Issuance window — child must be issued during parent's validity window.
+    if (cert.issuedAt < parent.issuedAt) {
+      details.push({
+        code: "ATP_TEMPORAL_OUT_OF_WINDOW",
+        reason: `chain[${i}] issuedAt < parent issuedAt`,
+        index: i,
+      });
+    }
+    if (cert.issuedAt > parent.expiresAt) {
+      details.push({
+        code: "ATP_TEMPORAL_OUT_OF_WINDOW",
+        reason: `chain[${i}] issuedAt > parent expiresAt`,
+        index: i,
+      });
+    }
+
+    // Sub-agent depth budget consumed by this hop.
+    if (parent.scope.maxSubAgentDepth < chain.chain.length - i) {
+      details.push({
+        code: "ATP_CHAIN_DEPTH_EXCEEDED",
+        reason: `chain[${i - 1}].scope.maxSubAgentDepth too small for descendants`,
+        index: i,
+      });
+    }
+  }
+
+  if (details.length > 0) {
+    return {
+      valid: false,
+      code: details[0]!.code,
+      reason: details[0]!.reason,
+      details,
+    };
+  }
+  return { valid: true };
+}
+
+/**
+ * Convenience: verify a chain and assert it ends with `expectedLeafCertId`.
+ * Useful when the leaf AIC is the one presenting the chain to a peer/tool.
+ */
+export function verifyChainTerminatesAt(
+  chain: TrustChain,
+  expectedLeafCertId: CertId,
+  opts?: VerifyTrustChainOptions,
+): VerificationResult {
+  const base = verifyTrustChain(chain, opts);
+  if (!base.valid) return base;
+  const actual = certIdOf(chain.chain[chain.chain.length - 1]!);
+  if (actual !== expectedLeafCertId) {
+    return {
+      valid: false,
+      code: "ATP_CHAIN_BROKEN",
+      reason: `chain leaf ${actual} != expected ${expectedLeafCertId}`,
+    };
+  }
+  return { valid: true };
+}

--- a/packages/atp/src/types.ts
+++ b/packages/atp/src/types.ts
@@ -1,0 +1,297 @@
+/**
+ * ATP — Agent Trust Protocol v1.0
+ *
+ * Type definitions for the five ATP primitives:
+ *   1. Agent Identity Certificate (AIC)
+ *   2. Action Receipt
+ *   3. Scope Declaration (SDL)
+ *   4. Trust Chain
+ *   5. Breach Attestation
+ *
+ * These types are the wire format. They are intentionally JSON-serialisable,
+ * deterministic, and flat — no class instances, no Date objects, no Buffers.
+ * Crypto uses Ed25519 throughout. All keys/signatures are base64-encoded
+ * (standard, not URL-safe, not PEM) for cross-language interop.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+/** Protocol version this implementation produces and validates. */
+export const ATP_VERSION = "1.0" as const;
+export type AtpVersion = typeof ATP_VERSION;
+
+// ─── Scope Declaration Language (SDL) ────────────────────────────────────────
+
+/**
+ * ScopeDeclaration — what an agent is authorised to do.
+ *
+ * Trust Chain rule: a child agent's scope MUST be a subset of its parent's
+ * (see {@link mergeScopes}, {@link verifyTrustChain}). This is the invariant
+ * that prevents the "spawn a sub-agent with broader powers" attack class.
+ */
+export interface ScopeDeclaration {
+  version: AtpVersion;
+
+  /** Allow-list of tools the agent may invoke. Empty array = no tools allowed. */
+  allowedTools: string[];
+
+  /** Optional explicit deny-list. Deny always wins over allow. */
+  deniedTools?: string[];
+
+  /**
+   * Optional allow-list of network domains. Globs supported (`*.example.com`).
+   * Absence means no network restriction is encoded by the scope (the engine's
+   * default policy decides). Presence means: only these domains.
+   */
+  allowedDomains?: string[];
+
+  /** How many levels of sub-agent spawning the holder may initiate. 0 = none. */
+  maxSubAgentDepth: number;
+
+  /** Tools that require a human approval signal before execution. */
+  requireApprovalFor?: string[];
+
+  /** Time-bound scoping. */
+  temporalScope?: {
+    /** Unix ms — earliest time the scope becomes valid. */
+    validFrom?: number;
+    /** Unix ms — last instant the scope is valid. */
+    validUntil?: number;
+    /** Allowed UTC hours-of-day (0–23). Empty array = no temporal hour gate. */
+    allowedHours?: number[];
+  };
+
+  /** Data classification scoping. */
+  dataScope?: {
+    /** Labels the agent may read/write (e.g. "public", "internal"). */
+    allowedLabels?: string[];
+    /** Labels explicitly forbidden (e.g. "secret", "pii"). */
+    deniedLabels?: string[];
+  };
+}
+
+// ─── Agent Identity Certificate (AIC) ────────────────────────────────────────
+
+/**
+ * AgentIdentityCertificate — the "passport" for an agent instance.
+ *
+ * Self-signed at issue time. The holder of `publicKey`'s matching private key
+ * is the agent. The signature covers the canonical JSON of every other field
+ * (signature itself excluded) using Ed25519.
+ */
+export interface AgentIdentityCertificate {
+  version: AtpVersion;
+
+  /** UUID v4 for this agent instance. */
+  agentId: string;
+
+  /** Logical model identifier, e.g. "anthropic/claude-sonnet-4-6". */
+  modelId: string;
+
+  /**
+   * Optional SHA-256 (hex) of the model weights for local/open-weight models.
+   * Hosted models without weight access leave this undefined.
+   */
+  modelHash?: string;
+
+  /** SHA-256 (hex) of the system prompt at agent initialisation time. */
+  systemPromptHash: string;
+
+  /** What this agent is authorised to do. */
+  scope: ScopeDeclaration;
+
+  /** Identifier of the human/org responsible for this agent. */
+  operatorId: string;
+
+  /** Unix ms — when the certificate was issued. */
+  issuedAt: number;
+
+  /** Unix ms — when the certificate expires. */
+  expiresAt: number;
+
+  /** Ed25519 public key, base64-standard encoded (32 raw bytes → 44 chars). */
+  publicKey: string;
+
+  /** Ed25519 signature over the canonical JSON of all other fields. */
+  signature: string;
+
+  /** If this agent was spawned by another agent: parent AIC's certId. */
+  parentCertId?: string;
+}
+
+/** Stable certificate identifier — SHA-256 (hex) of the canonical signed bytes. */
+export type CertId = string;
+
+// ─── Action Receipt ──────────────────────────────────────────────────────────
+
+/**
+ * ActionReceipt — tamper-proof record that an agent took an action.
+ *
+ * Signed by the agent's private key. The optional `receiverSignature` is a
+ * counter-signature from the tool/API that received the action, providing
+ * mutual non-repudiation when the receiver implements ATP.
+ */
+export interface ActionReceipt {
+  version: AtpVersion;
+
+  /** UUID v4 for this receipt. */
+  receiptId: string;
+
+  /** CertId of the AIC under which this action was taken. */
+  agentCertId: CertId;
+
+  /** What the agent did. */
+  action: {
+    /** Tool/action name (e.g. "send_email", "shell_exec"). */
+    tool: string;
+    /**
+     * Action parameters. SHOULD NOT contain secrets — use param hashes
+     * (`{ to_hash: "sha256:..." }`) when secrets are unavoidable.
+     */
+    params: Record<string, unknown>;
+    /** Unix ms — when the action was attempted. */
+    timestamp: number;
+  };
+
+  /** Outcome. */
+  result: {
+    success: boolean;
+    /** Non-sensitive human-readable summary of the result. */
+    summary: string;
+    /** Unix ms — when the result was observed. */
+    timestamp: number;
+  };
+
+  /** Ed25519 signature by the agent's private key. */
+  agentSignature: string;
+
+  /** Optional Ed25519 signature by the receiver (mutual non-repudiation). */
+  receiverSignature?: string;
+
+  /** Optional public key of the receiver (base64). Required if receiverSignature is set. */
+  receiverPublicKey?: string;
+}
+
+// ─── Trust Chain ─────────────────────────────────────────────────────────────
+
+/**
+ * TrustChain — a verified, ordered ancestry of AICs from root → leaf.
+ *
+ * Cryptographic invariants (enforced by {@link verifyTrustChain}):
+ *   1. Each child's `parentCertId` matches its predecessor's CertId.
+ *   2. Each AIC's signature is valid over its own contents.
+ *   3. Each child's scope is a subset of its parent's scope.
+ *   4. Each child's `issuedAt` is within its parent's validity window.
+ *   5. `chain.length === depth + 1` (root is depth 0).
+ */
+export interface TrustChain {
+  rootCertId: CertId;
+  chain: AgentIdentityCertificate[];
+  depth: number;
+}
+
+// ─── Breach Attestation ──────────────────────────────────────────────────────
+
+/**
+ * BreachAttestation — a signed snapshot of agent state, used to detect tampering.
+ *
+ * `stateHash` covers (in canonical order): systemPromptHash, memoryHash,
+ * toolCallHistoryHash. If the agent has been hijacked since the last
+ * attestation, recomputing the state hash will diverge and verification fails.
+ *
+ * Attestations form a hash chain via `previousHash` for forensic auditability.
+ */
+export interface BreachAttestation {
+  version: AtpVersion;
+
+  /** AgentId from the corresponding AIC. */
+  agentId: string;
+
+  /** Unix ms — when the attestation was generated. */
+  attestedAt: number;
+
+  /** SHA-256 (hex) of canonical-encoded state inputs. */
+  stateHash: string;
+
+  /** Hash of the previous attestation in the chain (hex SHA-256). */
+  previousHash?: string;
+
+  /** Ed25519 signature by the agent's private key. */
+  signature: string;
+
+  /** Optional third-party attestor identifier (e.g. "lyrie-verification-service"). */
+  attestorId?: string;
+
+  /** Optional Ed25519 counter-signature from the attestor. */
+  attestorSignature?: string;
+
+  /** Optional attestor public key (base64). Required if attestorSignature is set. */
+  attestorPublicKey?: string;
+}
+
+/**
+ * The state inputs that {@link attestState} hashes together. Ordering is
+ * fixed; clients must always supply the same shape so hashes are reproducible.
+ */
+export interface AgentState {
+  systemPromptHash: string;
+  /** SHA-256 (hex) over the canonical memory snapshot. */
+  memoryHash: string;
+  /** SHA-256 (hex) over the canonical tool-call history. */
+  toolCallHistoryHash: string;
+}
+
+// ─── Verification Results ────────────────────────────────────────────────────
+
+/** Generic validation result used by every ATP verifier. */
+export interface VerificationResult {
+  valid: boolean;
+  /** Machine-readable error code on failure. */
+  code?: VerificationErrorCode;
+  /** Human-readable reason. */
+  reason?: string;
+  /** Optional sub-results (e.g. trust-chain link errors). */
+  details?: Array<{ code: VerificationErrorCode; reason: string; index?: number }>;
+}
+
+/**
+ * Stable verification error codes. Treat as part of the public API — adding
+ * new ones is non-breaking, renaming existing ones is breaking.
+ */
+export type VerificationErrorCode =
+  | "ATP_VERSION_MISMATCH"
+  | "ATP_SIGNATURE_INVALID"
+  | "ATP_PUBLIC_KEY_INVALID"
+  | "ATP_CERT_EXPIRED"
+  | "ATP_CERT_NOT_YET_VALID"
+  | "ATP_CERT_REVOKED"
+  | "ATP_SCOPE_INVALID"
+  | "ATP_SCOPE_WIDENING"
+  | "ATP_CHAIN_BROKEN"
+  | "ATP_CHAIN_DEPTH_EXCEEDED"
+  | "ATP_RECEIPT_AGENT_MISMATCH"
+  | "ATP_ATTESTATION_DRIFT"
+  | "ATP_ATTESTATION_CHAIN_BROKEN"
+  | "ATP_TEMPORAL_OUT_OF_WINDOW"
+  | "ATP_TOOL_NOT_ALLOWED"
+  | "ATP_DOMAIN_NOT_ALLOWED"
+  | "ATP_MALFORMED";
+
+// ─── Key Pairs ───────────────────────────────────────────────────────────────
+
+/** Ed25519 key pair, both halves base64-standard encoded. */
+export interface AtpKeyPair {
+  publicKey: string;
+  privateKey: string;
+}
+
+// ─── Compliance Levels ───────────────────────────────────────────────────────
+
+/**
+ * ATP compliance levels — see Appendix B of the RFC.
+ *
+ * BASIC:    AIC + Action Receipts. The minimum.
+ * STANDARD: BASIC + SDL + Trust Chain enforcement.
+ * FULL:     STANDARD + periodic Breach Attestation.
+ */
+export type ComplianceLevel = "ATP-Basic" | "ATP-Standard" | "ATP-Full";

--- a/packages/atp/src/verify.ts
+++ b/packages/atp/src/verify.ts
@@ -1,0 +1,90 @@
+/**
+ * verify.ts — Cross-primitive verification entry point.
+ *
+ * One function to rule them all: pass any ATP artifact and an optional
+ * verification context, get a VerificationResult. Wraps the per-primitive
+ * verifiers with a discriminator so callers don't have to know which
+ * primitive type they're holding.
+ *
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import type {
+  ActionReceipt,
+  AgentIdentityCertificate,
+  BreachAttestation,
+  ScopeDeclaration,
+  TrustChain,
+  VerificationResult,
+} from "./types";
+import { verifyAic, type VerifyAicOptions } from "./aic";
+import { verifyReceipt, type VerifyReceiptOptions } from "./receipt";
+import { verifyTrustChain, type VerifyTrustChainOptions } from "./trust-chain";
+import { verifyAttestation, type VerifyAttestationOptions } from "./breach";
+import { validateScope } from "./scope";
+
+export type AtpArtifact =
+  | { kind: "aic"; cert: AgentIdentityCertificate }
+  | { kind: "receipt"; receipt: ActionReceipt }
+  | { kind: "scope"; scope: ScopeDeclaration }
+  | { kind: "trust-chain"; chain: TrustChain }
+  | { kind: "attestation"; attestation: BreachAttestation };
+
+export type AtpVerifyContext =
+  | { kind: "aic"; opts?: VerifyAicOptions }
+  | { kind: "receipt"; opts: VerifyReceiptOptions }
+  | { kind: "scope" }
+  | { kind: "trust-chain"; opts?: VerifyTrustChainOptions }
+  | { kind: "attestation"; opts: VerifyAttestationOptions };
+
+/**
+ * Verify any ATP artifact. The artifact and context kinds must match.
+ */
+export function verifyArtifact(
+  artifact: AtpArtifact,
+  context?: AtpVerifyContext,
+): VerificationResult {
+  if (context && context.kind !== artifact.kind) {
+    return {
+      valid: false,
+      code: "ATP_MALFORMED",
+      reason: `artifact kind ${artifact.kind} != context kind ${context.kind}`,
+    };
+  }
+  switch (artifact.kind) {
+    case "aic":
+      return verifyAic(artifact.cert, context?.kind === "aic" ? context.opts : undefined);
+    case "receipt": {
+      if (!context || context.kind !== "receipt") {
+        return { valid: false, code: "ATP_MALFORMED", reason: "receipt requires verify context with cert" };
+      }
+      return verifyReceipt(artifact.receipt, context.opts);
+    }
+    case "scope":
+      return validateScope(artifact.scope);
+    case "trust-chain":
+      return verifyTrustChain(artifact.chain, context?.kind === "trust-chain" ? context.opts : undefined);
+    case "attestation": {
+      if (!context || context.kind !== "attestation") {
+        return { valid: false, code: "ATP_MALFORMED", reason: "attestation requires verify context with cert" };
+      }
+      return verifyAttestation(artifact.attestation, context.opts);
+    }
+  }
+}
+
+/**
+ * Best-effort artifact discriminator — sniffs which ATP primitive a JSON
+ * blob is. Returns null if unrecognised. Useful for decoders that load
+ * mixed audit logs and need to dispatch.
+ */
+export function detectArtifactKind(value: unknown): AtpArtifact["kind"] | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  if ("agentSignature" in v && "action" in v && "result" in v) return "receipt";
+  if ("stateHash" in v && "attestedAt" in v) return "attestation";
+  if ("chain" in v && "rootCertId" in v) return "trust-chain";
+  if ("publicKey" in v && "signature" in v && "scope" in v) return "aic";
+  if ("allowedTools" in v && "maxSubAgentDepth" in v) return "scope";
+  return null;
+}

--- a/packages/atp/tests/aic.test.ts
+++ b/packages/atp/tests/aic.test.ts
@@ -1,0 +1,144 @@
+/**
+ * AIC tests — issuance, identity, signature, expiry, revocation.
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  issueAic,
+  certIdOf,
+  verifyAic,
+  RevocationRegistry,
+  ATP_VERSION,
+} from "../src/index";
+import { makeScope } from "../src/scope";
+import { sha256Hex } from "../src/crypto";
+
+const baseScope = () =>
+  makeScope({ allowedTools: ["read_file", "send_email"], maxSubAgentDepth: 0 });
+
+const baseInput = () => ({
+  modelId: "anthropic/claude-sonnet-4-6",
+  systemPromptHash: sha256Hex("system prompt"),
+  scope: baseScope(),
+  operatorId: "guy@lyrie.ai",
+});
+
+describe("AIC issuance", () => {
+  test("issues a valid certificate with fresh keys", () => {
+    const r = issueAic(baseInput());
+    expect(r.cert.version).toBe(ATP_VERSION);
+    expect(r.cert.agentId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(r.cert.publicKey.length).toBe(44);
+    expect(r.cert.signature.length).toBe(88);
+    expect(r.certId).toMatch(/^[0-9a-f]{64}$/);
+    expect(r.keyPair.privateKey.length).toBe(44);
+  });
+
+  test("preserves caller-provided agentId and key pair", () => {
+    const first = issueAic(baseInput());
+    const reissued = issueAic({
+      ...baseInput(),
+      agentId: first.cert.agentId,
+      keyPair: first.keyPair,
+    });
+    expect(reissued.cert.agentId).toBe(first.cert.agentId);
+    expect(reissued.cert.publicKey).toBe(first.cert.publicKey);
+  });
+
+  test("CertId is a deterministic SHA-256 of the canonical cert", () => {
+    const r = issueAic(baseInput());
+    expect(certIdOf(r.cert)).toBe(r.certId);
+  });
+
+  test("rejects invalid scope at issue time", () => {
+    expect(() =>
+      issueAic({
+        ...baseInput(),
+        scope: { ...baseScope(), maxSubAgentDepth: -1 },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("AIC verification", () => {
+  test("verifies a freshly issued cert", () => {
+    const r = issueAic(baseInput());
+    const v = verifyAic(r.cert);
+    expect(v.valid).toBe(true);
+  });
+
+  test("rejects a tampered scope", () => {
+    const r = issueAic(baseInput());
+    const tampered = { ...r.cert, scope: { ...r.cert.scope, maxSubAgentDepth: 99 } };
+    const v = verifyAic(tampered);
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_SIGNATURE_INVALID");
+  });
+
+  test("rejects a tampered model id", () => {
+    const r = issueAic(baseInput());
+    const tampered = { ...r.cert, modelId: "evil/backdoored-model" };
+    expect(verifyAic(tampered).valid).toBe(false);
+  });
+
+  test("rejects expired certs", () => {
+    const r = issueAic({ ...baseInput(), ttlMs: 10, issuedAt: Date.now() - 1000 });
+    const v = verifyAic(r.cert);
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_CERT_EXPIRED");
+  });
+
+  test("rejects not-yet-valid certs", () => {
+    const r = issueAic({ ...baseInput(), issuedAt: Date.now() + 60_000 });
+    const v = verifyAic(r.cert);
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_CERT_NOT_YET_VALID");
+  });
+
+  test("ignoreExpiry skips temporal checks", () => {
+    const r = issueAic({ ...baseInput(), ttlMs: 10, issuedAt: Date.now() - 1000 });
+    expect(verifyAic(r.cert, { ignoreExpiry: true }).valid).toBe(true);
+  });
+
+  test("revocation registry blocks listed certs", () => {
+    const r = issueAic(baseInput());
+    const reg = new RevocationRegistry();
+    expect(verifyAic(r.cert, { isRevoked: reg.isRevoked }).valid).toBe(true);
+    reg.revoke(r.certId);
+    const v = verifyAic(r.cert, { isRevoked: reg.isRevoked });
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_CERT_REVOKED");
+    reg.unrevoke(r.certId);
+    expect(verifyAic(r.cert, { isRevoked: reg.isRevoked }).valid).toBe(true);
+  });
+
+  test("rejects malformed objects", () => {
+    expect(verifyAic(null as never).valid).toBe(false);
+    expect(verifyAic({} as never).valid).toBe(false);
+    expect(verifyAic({ ...issueAic(baseInput()).cert, version: "0.9" } as never).valid).toBe(false);
+  });
+
+  test("rejects bad public key length", () => {
+    const r = issueAic(baseInput());
+    const tampered = { ...r.cert, publicKey: Buffer.from([1, 2, 3]).toString("base64") };
+    const v = verifyAic(tampered);
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_PUBLIC_KEY_INVALID");
+  });
+
+  test("rejects bad signature length", () => {
+    const r = issueAic(baseInput());
+    const tampered = { ...r.cert, signature: "shortsig" };
+    expect(verifyAic(tampered).valid).toBe(false);
+  });
+});
+
+describe("AIC parent linkage", () => {
+  test("supports parentCertId for sub-agents", () => {
+    const root = issueAic(baseInput());
+    const child = issueAic({ ...baseInput(), parentCertId: root.certId });
+    expect(child.cert.parentCertId).toBe(root.certId);
+    expect(verifyAic(child.cert).valid).toBe(true);
+  });
+});

--- a/packages/atp/tests/breach.test.ts
+++ b/packages/atp/tests/breach.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Breach Attestation tests.
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  issueAic,
+  attestState,
+  verifyAttestation,
+  hashAgentState,
+  attestationHash,
+  verifyAttestationChain,
+  addAttestorSignature,
+  generateKeyPair,
+} from "../src/index";
+import { makeScope } from "../src/scope";
+import { sha256Hex } from "../src/crypto";
+
+const baseInput = () => ({
+  modelId: "anthropic/claude-sonnet-4-6",
+  systemPromptHash: sha256Hex("p"),
+  scope: makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0 }),
+  operatorId: "guy@lyrie.ai",
+});
+
+const baseState = () => ({
+  systemPromptHash: sha256Hex("p"),
+  memoryHash: sha256Hex("memory"),
+  toolCallHistoryHash: sha256Hex("history"),
+});
+
+describe("hashAgentState", () => {
+  test("is deterministic", () => {
+    const a = hashAgentState(baseState());
+    const b = hashAgentState(baseState());
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("changes when any input changes", () => {
+    const original = hashAgentState(baseState());
+    const drifted = hashAgentState({ ...baseState(), memoryHash: sha256Hex("different") });
+    expect(original).not.toBe(drifted);
+  });
+});
+
+describe("attestState / verifyAttestation", () => {
+  test("issues a verifiable attestation", () => {
+    const r = issueAic(baseInput());
+    const att = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState() });
+    expect(att.signature.length).toBe(88);
+    expect(verifyAttestation(att, { cert: r.cert }).valid).toBe(true);
+  });
+
+  test("detects state drift when expectedStateHash differs", () => {
+    const r = issueAic(baseInput());
+    const att = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState() });
+    const v = verifyAttestation(att, { cert: r.cert, expectedStateHash: "0".repeat(64) });
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_ATTESTATION_DRIFT");
+  });
+
+  test("matches the expected state hash on the happy path", () => {
+    const r = issueAic(baseInput());
+    const state = baseState();
+    const att = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state });
+    const v = verifyAttestation(att, { cert: r.cert, expectedStateHash: hashAgentState(state) });
+    expect(v.valid).toBe(true);
+  });
+
+  test("rejects tampered stateHash", () => {
+    const r = issueAic(baseInput());
+    const att = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState() });
+    const tampered = { ...att, stateHash: sha256Hex("evil") };
+    expect(verifyAttestation(tampered, { cert: r.cert }).valid).toBe(false);
+  });
+
+  test("rejects mismatched agentId", () => {
+    const r = issueAic(baseInput());
+    const other = issueAic(baseInput());
+    const att = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState() });
+    expect(verifyAttestation(att, { cert: other.cert }).valid).toBe(false);
+  });
+
+  test("rejects malformed object", () => {
+    const r = issueAic(baseInput());
+    expect(verifyAttestation(null as never, { cert: r.cert }).valid).toBe(false);
+  });
+});
+
+describe("attestor counter-signature", () => {
+  test("verifies with a third-party attestor", () => {
+    const r = issueAic(baseInput());
+    const attestor = generateKeyPair();
+    const att = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState() });
+    const cs = addAttestorSignature(att, "lyrie-verification-service", attestor.privateKey, attestor.publicKey);
+    expect(cs.attestorId).toBe("lyrie-verification-service");
+    const v = verifyAttestation(cs, { cert: r.cert, requireAttestor: true });
+    expect(v.valid).toBe(true);
+  });
+
+  test("requireAttestor without one fails", () => {
+    const r = issueAic(baseInput());
+    const att = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState() });
+    const v = verifyAttestation(att, { cert: r.cert, requireAttestor: true });
+    expect(v.valid).toBe(false);
+  });
+
+  test("forged attestor signature fails", () => {
+    const r = issueAic(baseInput());
+    const real = generateKeyPair();
+    const fake = generateKeyPair();
+    const att = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState() });
+    const cs = addAttestorSignature(att, "x", fake.privateKey, real.publicKey);
+    expect(verifyAttestation(cs, { cert: r.cert }).valid).toBe(false);
+  });
+});
+
+describe("attestation chains", () => {
+  test("verifies a well-formed chain", () => {
+    const r = issueAic(baseInput());
+    const a1 = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState(), attestedAt: 100 });
+    const a2 = attestState({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      state: baseState(),
+      previousHash: attestationHash(a1),
+      attestedAt: 200,
+    });
+    const a3 = attestState({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      state: baseState(),
+      previousHash: attestationHash(a2),
+      attestedAt: 300,
+    });
+    const v = verifyAttestationChain([a1, a2, a3], r.cert);
+    expect(v.valid).toBe(true);
+  });
+
+  test("detects a broken hash link", () => {
+    const r = issueAic(baseInput());
+    const a1 = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState(), attestedAt: 100 });
+    const orphan = attestState({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      state: baseState(),
+      previousHash: "0".repeat(64),
+      attestedAt: 200,
+    });
+    const v = verifyAttestationChain([a1, orphan], r.cert);
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_ATTESTATION_CHAIN_BROKEN");
+  });
+
+  test("detects time going backwards", () => {
+    const r = issueAic(baseInput());
+    const a1 = attestState({ cert: r.cert, privateKey: r.keyPair.privateKey, state: baseState(), attestedAt: 200 });
+    const a2 = attestState({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      state: baseState(),
+      previousHash: attestationHash(a1),
+      attestedAt: 100,
+    });
+    const v = verifyAttestationChain([a1, a2], r.cert);
+    expect(v.valid).toBe(false);
+  });
+
+  test("rejects empty chain", () => {
+    const r = issueAic(baseInput());
+    expect(verifyAttestationChain([], r.cert).valid).toBe(false);
+  });
+});

--- a/packages/atp/tests/receipt.test.ts
+++ b/packages/atp/tests/receipt.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Action Receipt tests.
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  issueAic,
+  signReceipt,
+  verifyReceipt,
+  addReceiverSignature,
+  receiptsForCert,
+  generateKeyPair,
+} from "../src/index";
+import { makeScope } from "../src/scope";
+import { sha256Hex } from "../src/crypto";
+
+const baseInput = () => ({
+  modelId: "anthropic/claude-sonnet-4-6",
+  systemPromptHash: sha256Hex("p"),
+  scope: makeScope({ allowedTools: ["x"], maxSubAgentDepth: 0 }),
+  operatorId: "guy@lyrie.ai",
+});
+
+const sampleAction = (tool = "x") => ({
+  tool,
+  params: { y: 1 },
+  timestamp: 1_700_000_000_000,
+});
+const sampleResult = () => ({ success: true, summary: "ok", timestamp: 1_700_000_000_500 });
+
+describe("signReceipt", () => {
+  test("produces a verifiable receipt", () => {
+    const r = issueAic(baseInput());
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: sampleAction(),
+      result: sampleResult(),
+    });
+    expect(receipt.agentSignature.length).toBe(88);
+    expect(verifyReceipt(receipt, { cert: r.cert }).valid).toBe(true);
+  });
+
+  test("binds receipt to the issuing AIC", () => {
+    const a = issueAic(baseInput());
+    const b = issueAic(baseInput());
+    const receipt = signReceipt({
+      cert: a.cert,
+      privateKey: a.keyPair.privateKey,
+      action: sampleAction(),
+      result: sampleResult(),
+    });
+    const v = verifyReceipt(receipt, { cert: b.cert });
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_RECEIPT_AGENT_MISMATCH");
+  });
+
+  test("rejects tampered action params", () => {
+    const r = issueAic(baseInput());
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: sampleAction(),
+      result: sampleResult(),
+    });
+    const tampered = { ...receipt, action: { ...receipt.action, params: { y: 999 } } };
+    const v = verifyReceipt(tampered, { cert: r.cert });
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_SIGNATURE_INVALID");
+  });
+
+  test("rejects tampered result.success", () => {
+    const r = issueAic(baseInput());
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: sampleAction(),
+      result: sampleResult(),
+    });
+    const tampered = { ...receipt, result: { ...receipt.result, success: false } };
+    expect(verifyReceipt(tampered, { cert: r.cert }).valid).toBe(false);
+  });
+
+  test("rejects malformed receipt", () => {
+    const r = issueAic(baseInput());
+    expect(verifyReceipt(null as never, { cert: r.cert }).valid).toBe(false);
+    expect(verifyReceipt({} as never, { cert: r.cert }).valid).toBe(false);
+  });
+});
+
+describe("receiver counter-signature", () => {
+  test("can be added and verified", () => {
+    const r = issueAic(baseInput());
+    const receiver = generateKeyPair();
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: sampleAction(),
+      result: sampleResult(),
+    });
+    const counterSigned = addReceiverSignature(receipt, receiver.privateKey, receiver.publicKey);
+    expect(counterSigned.receiverSignature?.length).toBe(88);
+    const v = verifyReceipt(counterSigned, { cert: r.cert, requireReceiverSignature: true });
+    expect(v.valid).toBe(true);
+  });
+
+  test("requireReceiverSignature without one fails", () => {
+    const r = issueAic(baseInput());
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: sampleAction(),
+      result: sampleResult(),
+    });
+    const v = verifyReceipt(receipt, { cert: r.cert, requireReceiverSignature: true });
+    expect(v.valid).toBe(false);
+  });
+
+  test("agent signature stays valid after receiver counter-sign", () => {
+    const r = issueAic(baseInput());
+    const receiver = generateKeyPair();
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: sampleAction(),
+      result: sampleResult(),
+    });
+    const counterSigned = addReceiverSignature(receipt, receiver.privateKey, receiver.publicKey);
+    expect(verifyReceipt(counterSigned, { cert: r.cert }).valid).toBe(true);
+  });
+
+  test("forged receiver signature fails", () => {
+    const r = issueAic(baseInput());
+    const real = generateKeyPair();
+    const fake = generateKeyPair();
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: sampleAction(),
+      result: sampleResult(),
+    });
+    const cs = addReceiverSignature(receipt, fake.privateKey, real.publicKey);
+    const v = verifyReceipt(cs, { cert: r.cert });
+    expect(v.valid).toBe(false);
+  });
+});
+
+describe("receipt log helpers", () => {
+  test("filters by certId", () => {
+    const a = issueAic(baseInput());
+    const b = issueAic(baseInput());
+    const r1 = signReceipt({ cert: a.cert, privateKey: a.keyPair.privateKey, action: sampleAction(), result: sampleResult() });
+    const r2 = signReceipt({ cert: a.cert, privateKey: a.keyPair.privateKey, action: sampleAction("y"), result: sampleResult() });
+    const r3 = signReceipt({ cert: b.cert, privateKey: b.keyPair.privateKey, action: sampleAction(), result: sampleResult() });
+    expect(receiptsForCert([r1, r2, r3], a.certId)).toEqual([r1, r2]);
+  });
+});

--- a/packages/atp/tests/scope.test.ts
+++ b/packages/atp/tests/scope.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Scope / SDL tests — validation, subset, merge, decisions.
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  makeScope,
+  parseScope,
+  validateScope,
+  isScopeSubset,
+  mergeScopes,
+  domainCovers,
+  checkToolAllowed,
+  checkDomainAllowed,
+  checkTemporallyValid,
+} from "../src/scope";
+
+describe("scope validation", () => {
+  test("accepts a minimal valid scope", () => {
+    const s = makeScope({ allowedTools: [], maxSubAgentDepth: 0 });
+    expect(validateScope(s).valid).toBe(true);
+  });
+
+  test("rejects bad maxSubAgentDepth", () => {
+    expect(validateScope(makeScope({ allowedTools: [], maxSubAgentDepth: -1 })).valid).toBe(false);
+    expect(validateScope({ ...makeScope({ allowedTools: [], maxSubAgentDepth: 0 }), maxSubAgentDepth: 1.5 }).valid).toBe(false);
+  });
+
+  test("rejects bad temporal hours", () => {
+    const s = makeScope({ allowedTools: [], maxSubAgentDepth: 0, temporalScope: { allowedHours: [25] } });
+    expect(validateScope(s).valid).toBe(false);
+  });
+
+  test("rejects validFrom > validUntil", () => {
+    const s = makeScope({ allowedTools: [], maxSubAgentDepth: 0, temporalScope: { validFrom: 100, validUntil: 50 } });
+    expect(validateScope(s).valid).toBe(false);
+  });
+
+  test("parseScope round-trips JSON", () => {
+    const s = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 1 });
+    const parsed = parseScope(JSON.stringify(s));
+    expect(parsed.allowedTools).toEqual(["a"]);
+  });
+
+  test("parseScope rejects garbage", () => {
+    expect(() => parseScope("{}")).toThrow();
+  });
+});
+
+describe("scope subset", () => {
+  test("identical scopes are subsets of themselves", () => {
+    const s = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 2 });
+    expect(isScopeSubset(s, s)).toBe(true);
+  });
+
+  test("child cannot widen tools", () => {
+    const parent = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 1 });
+    const child = makeScope({ allowedTools: ["a", "b"], maxSubAgentDepth: 1 });
+    expect(isScopeSubset(child, parent)).toBe(false);
+    expect(isScopeSubset(parent, child)).toBe(true);
+  });
+
+  test("wildcard parent admits any child tool", () => {
+    const parent = makeScope({ allowedTools: ["*"], maxSubAgentDepth: 5 });
+    const child = makeScope({ allowedTools: ["a", "b"], maxSubAgentDepth: 1 });
+    expect(isScopeSubset(child, parent)).toBe(true);
+  });
+
+  test("parent denied tool blocks any child claim", () => {
+    const parent = makeScope({ allowedTools: ["*"], deniedTools: ["dangerous"], maxSubAgentDepth: 1 });
+    const child = makeScope({ allowedTools: ["dangerous"], maxSubAgentDepth: 0 });
+    expect(isScopeSubset(child, parent)).toBe(false);
+  });
+
+  test("child must inherit parent's deny list", () => {
+    const parent = makeScope({ allowedTools: ["*"], deniedTools: ["danger"], maxSubAgentDepth: 1 });
+    const childMissing = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0 });
+    const childKeeps = makeScope({ allowedTools: ["a"], deniedTools: ["danger"], maxSubAgentDepth: 0 });
+    expect(isScopeSubset(childMissing, parent)).toBe(false);
+    expect(isScopeSubset(childKeeps, parent)).toBe(true);
+  });
+
+  test("child cannot increase sub-agent depth", () => {
+    const parent = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 1 });
+    const child = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 2 });
+    expect(isScopeSubset(child, parent)).toBe(false);
+  });
+
+  test("scoped parent rejects open-ended child domains", () => {
+    const parent = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, allowedDomains: ["*.x.com"] });
+    const childOpen = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0 });
+    const childMatch = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, allowedDomains: ["a.x.com"] });
+    const childOff = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, allowedDomains: ["evil.com"] });
+    expect(isScopeSubset(childOpen, parent)).toBe(false);
+    expect(isScopeSubset(childMatch, parent)).toBe(true);
+    expect(isScopeSubset(childOff, parent)).toBe(false);
+  });
+
+  test("temporal window must be within parent's", () => {
+    const parent = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, temporalScope: { validFrom: 100, validUntil: 200 } });
+    const inside = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, temporalScope: { validFrom: 120, validUntil: 180 } });
+    const outside = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, temporalScope: { validFrom: 50, validUntil: 180 } });
+    expect(isScopeSubset(inside, parent)).toBe(true);
+    expect(isScopeSubset(outside, parent)).toBe(false);
+  });
+
+  test("data labels must be subset", () => {
+    const parent = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, dataScope: { allowedLabels: ["public", "internal"] } });
+    const ok = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, dataScope: { allowedLabels: ["public"] } });
+    const wider = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, dataScope: { allowedLabels: ["public", "secret"] } });
+    expect(isScopeSubset(ok, parent)).toBe(true);
+    expect(isScopeSubset(wider, parent)).toBe(false);
+  });
+});
+
+describe("mergeScopes", () => {
+  test("intersection narrows tools", () => {
+    const parent = makeScope({ allowedTools: ["a", "b"], maxSubAgentDepth: 5 });
+    const child = makeScope({ allowedTools: ["b", "c"], maxSubAgentDepth: 2 });
+    const merged = mergeScopes(parent, child);
+    expect(merged.allowedTools).toEqual(["b"]);
+    expect(merged.maxSubAgentDepth).toBe(2);
+    expect(isScopeSubset(merged, parent)).toBe(true);
+  });
+
+  test("union of denied tools", () => {
+    const parent = makeScope({ allowedTools: ["*"], deniedTools: ["x"], maxSubAgentDepth: 1 });
+    const child = makeScope({ allowedTools: ["a"], deniedTools: ["y"], maxSubAgentDepth: 0 });
+    const merged = mergeScopes(parent, child);
+    expect(merged.deniedTools).toContain("x");
+    expect(merged.deniedTools).toContain("y");
+  });
+
+  test("temporal intersection", () => {
+    const parent = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, temporalScope: { validFrom: 100, validUntil: 500 } });
+    const child = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0, temporalScope: { validFrom: 200, validUntil: 700 } });
+    const merged = mergeScopes(parent, child);
+    expect(merged.temporalScope?.validFrom).toBe(200);
+    expect(merged.temporalScope?.validUntil).toBe(500);
+  });
+});
+
+describe("domain glob", () => {
+  test("exact match", () => {
+    expect(domainCovers("a.com", "a.com")).toBe(true);
+    expect(domainCovers("a.com", "b.com")).toBe(false);
+  });
+  test("wildcard subdomain", () => {
+    expect(domainCovers("*.x.com", "api.x.com")).toBe(true);
+    expect(domainCovers("*.x.com", "x.com")).toBe(false);
+    expect(domainCovers("*.x.com", "a.b.x.com")).toBe(true);
+    expect(domainCovers("*.x.com", "evil.com")).toBe(false);
+  });
+  test("global wildcard", () => {
+    expect(domainCovers("*", "anything.com")).toBe(true);
+  });
+});
+
+describe("decision helpers", () => {
+  const scope = makeScope({
+    allowedTools: ["read", "write"],
+    deniedTools: ["delete"],
+    requireApprovalFor: ["write"],
+    allowedDomains: ["*.x.com"],
+    maxSubAgentDepth: 0,
+    temporalScope: { validFrom: 100, validUntil: 200 },
+  });
+
+  test("checkToolAllowed reflects allow / deny / approval", () => {
+    expect(checkToolAllowed("read", scope)).toEqual({ allowed: true, requiresApproval: false });
+    expect(checkToolAllowed("write", scope)).toEqual({ allowed: true, requiresApproval: true });
+    expect(checkToolAllowed("delete", scope).allowed).toBe(false);
+    expect(checkToolAllowed("unknown", scope).allowed).toBe(false);
+  });
+
+  test("checkDomainAllowed honors globs", () => {
+    expect(checkDomainAllowed("api.x.com", scope)).toBe(true);
+    expect(checkDomainAllowed("evil.com", scope)).toBe(false);
+  });
+
+  test("temporal validity respects window", () => {
+    expect(checkTemporallyValid(scope, 50)).toBe(false);
+    expect(checkTemporallyValid(scope, 150)).toBe(true);
+    expect(checkTemporallyValid(scope, 250)).toBe(false);
+  });
+
+  test("checkDomainAllowed defaults open when no allowedDomains", () => {
+    const s = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0 });
+    expect(checkDomainAllowed("anywhere.io", s)).toBe(true);
+  });
+});

--- a/packages/atp/tests/trust-chain.test.ts
+++ b/packages/atp/tests/trust-chain.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Trust Chain tests — the cornerstone privilege-escalation prevention rule.
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  issueAic,
+  buildTrustChain,
+  verifyTrustChain,
+  verifyChainTerminatesAt,
+  certIdOf,
+} from "../src/index";
+import { makeScope } from "../src/scope";
+import { sha256Hex } from "../src/crypto";
+
+const wide = makeScope({ allowedTools: ["a", "b", "c"], maxSubAgentDepth: 3 });
+const narrow = makeScope({ allowedTools: ["a", "b"], maxSubAgentDepth: 2 });
+const narrower = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 1 });
+
+const opInput = (scope = wide, parentCertId?: string) => ({
+  modelId: "anthropic/claude-sonnet-4-6",
+  systemPromptHash: sha256Hex("p"),
+  scope,
+  operatorId: "guy@lyrie.ai",
+  parentCertId,
+});
+
+describe("buildTrustChain", () => {
+  test("requires at least one cert", () => {
+    expect(() => buildTrustChain([])).toThrow();
+  });
+
+  test("computes depth correctly", () => {
+    const root = issueAic(opInput());
+    const chain = buildTrustChain([root.cert]);
+    expect(chain.depth).toBe(0);
+    expect(chain.rootCertId).toBe(root.certId);
+  });
+});
+
+describe("verifyTrustChain — happy paths", () => {
+  test("single root verifies", () => {
+    const root = issueAic(opInput());
+    const v = verifyTrustChain(buildTrustChain([root.cert]));
+    expect(v.valid).toBe(true);
+  });
+
+  test("two-level narrowing chain verifies", () => {
+    const root = issueAic(opInput(wide));
+    const child = issueAic(opInput(narrow, root.certId));
+    const v = verifyTrustChain(buildTrustChain([root.cert, child.cert]));
+    expect(v.valid).toBe(true);
+  });
+
+  test("three-level monotonically narrowing chain verifies", () => {
+    const root = issueAic(opInput(wide));
+    const mid = issueAic(opInput(narrow, root.certId));
+    const leaf = issueAic(opInput(narrower, mid.certId));
+    const v = verifyTrustChain(buildTrustChain([root.cert, mid.cert, leaf.cert]));
+    expect(v.valid).toBe(true);
+  });
+});
+
+describe("verifyTrustChain — invariant enforcement", () => {
+  test("rejects scope-widening child (the headline rule)", () => {
+    const root = issueAic(opInput(narrow));
+    const evil = issueAic(opInput(wide, root.certId));
+    const v = verifyTrustChain(buildTrustChain([root.cert, evil.cert]));
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_SCOPE_WIDENING");
+  });
+
+  test("rejects broken parent linkage", () => {
+    const root = issueAic(opInput(wide));
+    const child = issueAic(opInput(narrow, "bogus".repeat(13).slice(0, 64)));
+    const v = verifyTrustChain(buildTrustChain([root.cert, child.cert]));
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_CHAIN_BROKEN");
+  });
+
+  test("rejects root with parentCertId", () => {
+    const fakeParent = "a".repeat(64);
+    const root = issueAic(opInput(wide, fakeParent));
+    const v = verifyTrustChain(buildTrustChain([root.cert]));
+    expect(v.valid).toBe(false);
+  });
+
+  test("rejects child issued before parent issuedAt", () => {
+    const now = Date.now();
+    const root = issueAic({ ...opInput(wide), issuedAt: now });
+    const earlyChild = issueAic({ ...opInput(narrow, root.certId), issuedAt: now - 60_000 });
+    const v = verifyTrustChain(buildTrustChain([root.cert, earlyChild.cert]));
+    expect(v.valid).toBe(false);
+  });
+
+  test("rejects child issued after parent expiresAt", () => {
+    const root = issueAic({ ...opInput(wide), ttlMs: 100, issuedAt: Date.now() - 10_000 });
+    const lateChild = issueAic({ ...opInput(narrow, root.certId), issuedAt: Date.now() });
+    const v = verifyTrustChain(buildTrustChain([root.cert, lateChild.cert]), { ignoreExpiry: true });
+    expect(v.valid).toBe(false);
+  });
+
+  test("global maxDepth is enforced", () => {
+    const root = issueAic(opInput(wide));
+    const child = issueAic(opInput(narrow, root.certId));
+    const v = verifyTrustChain(buildTrustChain([root.cert, child.cert]), { maxDepth: 0 });
+    expect(v.valid).toBe(false);
+    expect(v.code).toBe("ATP_CHAIN_DEPTH_EXCEEDED");
+  });
+
+  test("parent's maxSubAgentDepth caps the chain", () => {
+    const tightRoot = issueAic(opInput(makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0 })));
+    const childScope = makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0 });
+    const child = issueAic(opInput(childScope, tightRoot.certId));
+    const v = verifyTrustChain(buildTrustChain([tightRoot.cert, child.cert]));
+    expect(v.valid).toBe(false);
+  });
+
+  test("collects multiple errors in details", () => {
+    const root = issueAic(opInput(narrow));
+    const widening = issueAic(opInput(wide, root.certId));
+    const v = verifyTrustChain(buildTrustChain([root.cert, widening.cert]));
+    expect(v.valid).toBe(false);
+    expect(v.details?.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("rejects empty chain", () => {
+    const v = verifyTrustChain({ rootCertId: "x", chain: [], depth: 0 });
+    expect(v.valid).toBe(false);
+  });
+
+  test("rejects depth/length mismatch", () => {
+    const root = issueAic(opInput());
+    const v = verifyTrustChain({ rootCertId: root.certId, chain: [root.cert], depth: 5 });
+    expect(v.valid).toBe(false);
+  });
+});
+
+describe("verifyChainTerminatesAt", () => {
+  test("matches expected leaf", () => {
+    const root = issueAic(opInput(wide));
+    const child = issueAic(opInput(narrow, root.certId));
+    const chain = buildTrustChain([root.cert, child.cert]);
+    expect(verifyChainTerminatesAt(chain, certIdOf(child.cert)).valid).toBe(true);
+  });
+
+  test("rejects mismatched leaf", () => {
+    const root = issueAic(opInput());
+    const chain = buildTrustChain([root.cert]);
+    const v = verifyChainTerminatesAt(chain, "z".repeat(64));
+    expect(v.valid).toBe(false);
+  });
+});

--- a/packages/atp/tests/verify.test.ts
+++ b/packages/atp/tests/verify.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Cross-primitive verifier + badge tests.
+ * © OTT Cybersecurity LLC — https://lyrie.ai
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  issueAic,
+  signReceipt,
+  attestState,
+  buildTrustChain,
+  verifyArtifact,
+  detectArtifactKind,
+  generateBadge,
+  makeScope,
+  canonicalize,
+  generateKeyPair,
+} from "../src/index";
+import { sha256Hex } from "../src/crypto";
+
+const baseInput = () => ({
+  modelId: "anthropic/claude-sonnet-4-6",
+  systemPromptHash: sha256Hex("p"),
+  scope: makeScope({ allowedTools: ["a"], maxSubAgentDepth: 1 }),
+  operatorId: "guy@lyrie.ai",
+});
+
+describe("verifyArtifact dispatch", () => {
+  test("verifies an AIC", () => {
+    const r = issueAic(baseInput());
+    expect(verifyArtifact({ kind: "aic", cert: r.cert }).valid).toBe(true);
+  });
+
+  test("verifies a receipt", () => {
+    const r = issueAic(baseInput());
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: { tool: "a", params: {}, timestamp: 1 },
+      result: { success: true, summary: "", timestamp: 2 },
+    });
+    const v = verifyArtifact({ kind: "receipt", receipt }, { kind: "receipt", opts: { cert: r.cert } });
+    expect(v.valid).toBe(true);
+  });
+
+  test("verifies a trust chain", () => {
+    const root = issueAic(baseInput());
+    const child = issueAic({ ...baseInput(), parentCertId: root.certId, scope: makeScope({ allowedTools: ["a"], maxSubAgentDepth: 0 }) });
+    const chain = buildTrustChain([root.cert, child.cert]);
+    expect(verifyArtifact({ kind: "trust-chain", chain }).valid).toBe(true);
+  });
+
+  test("verifies an attestation", () => {
+    const r = issueAic(baseInput());
+    const att = attestState({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      state: { systemPromptHash: "a", memoryHash: "b", toolCallHistoryHash: "c" },
+    });
+    const v = verifyArtifact(
+      { kind: "attestation", attestation: att },
+      { kind: "attestation", opts: { cert: r.cert } },
+    );
+    expect(v.valid).toBe(true);
+  });
+
+  test("validates a scope artifact", () => {
+    const v = verifyArtifact({ kind: "scope", scope: makeScope({ allowedTools: [], maxSubAgentDepth: 0 }) });
+    expect(v.valid).toBe(true);
+  });
+
+  test("rejects mismatched artifact + context kinds", () => {
+    const r = issueAic(baseInput());
+    const v = verifyArtifact(
+      { kind: "aic", cert: r.cert },
+      { kind: "receipt", opts: { cert: r.cert } },
+    );
+    expect(v.valid).toBe(false);
+  });
+});
+
+describe("detectArtifactKind", () => {
+  test("identifies AIC", () => {
+    const r = issueAic(baseInput());
+    expect(detectArtifactKind(r.cert)).toBe("aic");
+  });
+
+  test("identifies receipt", () => {
+    const r = issueAic(baseInput());
+    const receipt = signReceipt({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      action: { tool: "a", params: {}, timestamp: 1 },
+      result: { success: true, summary: "", timestamp: 2 },
+    });
+    expect(detectArtifactKind(receipt)).toBe("receipt");
+  });
+
+  test("identifies attestation", () => {
+    const r = issueAic(baseInput());
+    const att = attestState({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      state: { systemPromptHash: "a", memoryHash: "b", toolCallHistoryHash: "c" },
+    });
+    expect(detectArtifactKind(att)).toBe("attestation");
+  });
+
+  test("returns null for noise", () => {
+    expect(detectArtifactKind(null)).toBe(null);
+    expect(detectArtifactKind({ unrelated: true })).toBe(null);
+  });
+});
+
+describe("badge", () => {
+  test("ATP-Full when attestation supplied", () => {
+    const r = issueAic(baseInput());
+    const att = attestState({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      state: { systemPromptHash: "a", memoryHash: "b", toolCallHistoryHash: "c" },
+    });
+    const badge = generateBadge(r.cert, att);
+    expect(badge.json.level).toBe("ATP-Full");
+    expect(badge.svg.startsWith("<svg")).toBe(true);
+    expect(badge.verifyUrl.startsWith("https://lyrie.ai/verify?cert=")).toBe(true);
+    expect(badge.json.cert).toEqual(r.cert);
+  });
+
+  test("level override is respected", () => {
+    const r = issueAic(baseInput());
+    const att = attestState({
+      cert: r.cert,
+      privateKey: r.keyPair.privateKey,
+      state: { systemPromptHash: "a", memoryHash: "b", toolCallHistoryHash: "c" },
+    });
+    const badge = generateBadge(r.cert, att, { level: "ATP-Basic", verifyBaseUrl: "https://x.test/v" });
+    expect(badge.json.level).toBe("ATP-Basic");
+    expect(badge.verifyUrl.startsWith("https://x.test/v?cert=")).toBe(true);
+  });
+});
+
+describe("canonical JSON", () => {
+  test("orders keys lexicographically", () => {
+    const a = canonicalize({ b: 1, a: 2, c: { y: 1, x: 2 } });
+    expect(a).toBe('{"a":2,"b":1,"c":{"x":2,"y":1}}');
+  });
+
+  test("drops undefined values", () => {
+    const a = canonicalize({ a: undefined, b: 1 });
+    expect(a).toBe('{"b":1}');
+  });
+
+  test("rejects functions and bigint", () => {
+    expect(() => canonicalize({ f: () => 0 })).toThrow();
+    expect(() => canonicalize({ n: 1n })).toThrow();
+  });
+});
+
+describe("crypto sanity", () => {
+  test("generated keys are 32 raw bytes each", () => {
+    const kp = generateKeyPair();
+    expect(Buffer.from(kp.publicKey, "base64").length).toBe(32);
+    expect(Buffer.from(kp.privateKey, "base64").length).toBe(32);
+  });
+});

--- a/packages/atp/tsconfig.json
+++ b/packages/atp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
Implements the **Agent Trust Protocol (ATP) v1.0** — Lyrie's cryptographic identity and trust-chain standard for autonomous agents.

## What It Does
- **AIC (Agent Identity Certificate)** — Ed25519-signed agent identity with scope constraints
- **Trust Chain** — multi-hop agent delegation with chain validation
- **Receipt System** — tamper-evident action receipts for auditability
- **Breach Detection** — real-time trust violation alerting
- **Scope Enforcement** — capability scoping to prevent privilege escalation

## Key Files
| File | Purpose |
|------|---------|
| `packages/atp/src/aic.ts` | Agent Identity Certificate issuance & verification |
| `packages/atp/src/trust-chain.ts` | Multi-hop delegation chain |
| `packages/atp/src/receipt.ts` | Action receipt generation |
| `packages/atp/src/breach.ts` | Breach detection & alerting |
| `packages/atp/src/crypto.ts` | Ed25519 signing primitives |
| `packages/atp/src/scope.ts` | Capability scope enforcement |

## Tests
6 test files covering AIC, breach, receipt, scope, trust-chain, and verify — all passing.

## Part of
Lyrie v1.0.0 feature set. See `feat/v1.0.0-integration` for the full integration (1,099 tests passing).